### PR TITLE
Bumps version to 0.1.1; updates URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "ion-tests"]
 	path = vectors
-	url = https://github.com/amznlabs/ion-tests
+	url = https://github.com/amzn/ion-tests
 	branch = master

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,7 @@
+### 0.1.1 (2017-05-09)
+* Added support for reading text Ion
+* Fixed bug affecting writes of large binary Ion values
+
+### 0.1.0 (2016-10-20)
+* Added support for writing text Ion
+* Added support for reading and writing binary Ion

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Amazon Ion Python
-Copyright 2007-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2007-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Amazon Ion Python
-An implementation of [Amazon Ion](https://amznlabs.github.io/ion-docs/)
+An implementation of [Amazon Ion](https://amzn.github.io/ion-docs/)
 for Python.
 
-[![Build Status](https://travis-ci.org/amznlabs/ion-python.svg?branch=master)](https://travis-ci.org/amznlabs/ion-python)
+[![Build Status](https://travis-ci.org/amzn/ion-python.svg?branch=master)](https://travis-ci.org/amzn/ion-python)
 
 This package is designed to work with **Python 2.6+** and **Python 3.3+**
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2016-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License").
 # You may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ setup(
     name='amazon.ion',
     version='0.1.1',
     description='A Python implementation of Amazon Ion.',
-    url='http://github.com/amznlabs/ion-python',
+    url='http://github.com/amzn/ion-python',
     author='Amazon Ion Team',
     author_email='ion-team@amazon.com',
     license='Apache License 2.0',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='amazon.ion',
-    version='0.1.0post1',
+    version='0.1.1',
     description='A Python implementation of Amazon Ion.',
     url='http://github.com/amznlabs/ion-python',
     author='Amazon Ion Team',


### PR DESCRIPTION
* The last version on PyPI is from Oct 20, 2016, and doesn't include text reading support. I plan to release this version as 0.1.1.
* URLs have been updated from amznlabs -> amzn