### PR TITLE
Adding an implementation of simpleion.dumps

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -207,8 +207,46 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan
           separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
           tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
           ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
-    """Not yet implemented"""
-    raise IonException("Not yet implemented")
+    """Serialize ``obj`` as an Ion string, using the conversion table used by ``dump`` (above).
+
+    Args:
+        obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
+            instance of or inherits from one of the types in the above table will raise TypeError.
+        skipkeys: NOT IMPLEMENTED
+        ensure_ascii: NOT IMPLEMENTED
+        check_circular: NOT IMPLEMENTED
+        allow_nan: NOT IMPLEMENTED
+        cls: NOT IMPLEMENTED
+        indent: NOT IMPLEMENTED
+        separators: NOT IMPLEMENTED
+        encoding: NOT IMPLEMENTED
+        default: NOT IMPLEMENTED
+        use_decimal: NOT IMPLEMENTED
+        namedtuple_as_object: NOT IMPLEMENTED
+        tuple_as_array: NOT IMPLEMENTED
+        bigint_as_string: NOT IMPLEMENTED
+        sort_keys: NOT IMPLEMENTED
+        item_sort_key: NOT IMPLEMENTED
+        for_json: NOT IMPLEMENTED
+        ignore_nan: NOT IMPLEMENTED
+        int_as_string_bitcount: NOT IMPLEMENTED
+        iterable_as_array: NOT IMPLEMENTED
+        **kw: NOT IMPLEMENTED
+
+    Returns:
+        str: Ion clob representation of ``obj``
+    """
+    ion_buffer = six.BytesIO()
+
+    dump(obj, ion_buffer, binary=False, skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
+         allow_nan=allow_nan, cls=cls, indent=indent, separators=separators, encoding=encoding, default=default,
+         use_decimal=use_decimal, namedtuple_as_object=namedtuple_as_object, tuple_as_array=tuple_as_array,
+         bigint_as_string=bigint_as_string, sort_keys=sort_keys, item_sort_key=item_sort_key, for_json=for_json,
+         ignore_nan=ignore_nan, int_as_string_bitcount=int_as_string_bitcount, iterable_as_array=iterable_as_array)
+
+    ion_str = ion_buffer.getvalue().decode('utf-8')
+    ion_buffer.close()
+    return ion_str
 
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -101,7 +101,7 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
 
     Args:
         obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
-            instance of or inherits from one of the types in the above table will raise TypeError.
+            instance of nor inherits from one of the types in the above table will raise TypeError.
         fp (BaseIO): A file-like object.
         imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
         binary (Optional[True|False]): When True, outputs binary Ion. When false, outputs text Ion.
@@ -212,7 +212,7 @@ def dumps(obj, imports=None, sequence_as_stream=False, skipkeys=False, ensure_as
 
     Args:
         obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
-            instance of or inherits from one of the types in the above table will raise TypeError.
+            instance of nor inherits from one of the types in the above table will raise TypeError.
         imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
         sequence_as_stream (Optional[True|False]): When True, if ``obj`` is a sequence, it will be treated as a stream
             of top-level Ion values (i.e. the resulting Ion data will begin with ``obj``'s first element).

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -45,10 +45,11 @@ _IVM = b'\xe0\x01\x00\xea'
 _TEXT_TYPES = (TextIOBase, six.StringIO)
 
 
-def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
-         separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
-         tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
-         ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True,
+         check_circular=True, allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8', default=None,
+         use_decimal=True, namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False, sort_keys=False,
+         item_sort_key=None, for_json=None, ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False,
+         **kw):
     """Serialize ``obj`` as an Ion-formatted stream to ``fp`` (a file-like object), using the following conversion
     table::
         +-------------------+-------------------+
@@ -203,15 +204,19 @@ def _dump(obj, writer, field=None):
     writer.send(event)
 
 
-def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan=True, cls=None, indent=None,
-          separators=None, encoding='utf-8', default=None, use_decimal=True, namedtuple_as_object=True,
-          tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None, for_json=None,
-          ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
+def dumps(obj, imports=None, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True,
+          allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8', default=None, use_decimal=True,
+          namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None,
+          for_json=None, ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
     """Serialize ``obj`` as an Ion string, using the conversion table used by ``dump`` (above).
 
     Args:
         obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
             instance of or inherits from one of the types in the above table will raise TypeError.
+        imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
+        sequence_as_stream (Optional[True|False]): When True, if ``obj`` is a sequence, it will be treated as a stream
+            of top-level Ion values (i.e. the resulting Ion data will begin with ``obj``'s first element).
+            Default: False.
         skipkeys: NOT IMPLEMENTED
         ensure_ascii: NOT IMPLEMENTED
         check_circular: NOT IMPLEMENTED
@@ -238,7 +243,7 @@ def dumps(obj, skipkeys=False, ensure_ascii=True, check_circular=True, allow_nan
     """
     ion_buffer = six.BytesIO()
 
-    dump(obj, ion_buffer, binary=False, skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
+    dump(obj, ion_buffer, sequence_as_stream=sequence_as_stream, binary=False, skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
          allow_nan=allow_nan, cls=cls, indent=indent, separators=separators, encoding=encoding, default=default,
          use_decimal=use_decimal, namedtuple_as_object=namedtuple_as_object, tuple_as_array=tuple_as_array,
          bigint_as_string=bigint_as_string, sort_keys=sort_keys, item_sort_key=item_sort_key, for_json=for_json,

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -329,10 +329,10 @@ def test_dumps(p):
     # test dumps
     res = dumps(p.obj, sequence_as_stream=p.stream)
     if not p.has_symbols:
-        assert (b'$ion_1_0 ' + p.expected) == res
+        assert (b'$ion_1_0 ' + p.expected).decode('utf-8') == res
     else:
         # The payload contains a LST. The value comes last, so compare the end bytes.
-        assert p.expected == res[len(res) - len(p.expected):]
+        assert (p.expected).decode('utf-8') == res[len(res) - len(p.expected):]
 
 
 _ROUNDTRIPS = [

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -29,7 +29,7 @@ from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol, _IonNature
 from amazon.ion.equivalence import ion_equals
-from amazon.ion.simpleion import dump, load, _ion_type, _FROM_ION_TYPE
+from amazon.ion.simpleion import dump, dumps, load, _ion_type, _FROM_ION_TYPE
 from amazon.ion.util import record
 from amazon.ion.writer_binary_raw import _serialize_symbol, _write_length
 from tests.writer_util import VARUINT_END_BYTE, ION_ENCODED_INT_ZERO, SIMPLE_SCALARS_MAP_BINARY, SIMPLE_SCALARS_MAP_TEXT
@@ -316,6 +316,23 @@ def test_dump_load_text(p):
                 return False
     if not equals():
         assert ion_equals(p.obj, res)  # Redundant, but provides better error message.
+
+
+@parametrize(
+    *tuple(chain(
+        generate_scalars_text(SIMPLE_SCALARS_MAP_TEXT),
+        generate_containers_text(_SIMPLE_CONTAINER_MAP),
+        generate_annotated_values_text(SIMPLE_SCALARS_MAP_TEXT, _SIMPLE_CONTAINER_MAP),
+    ))
+)
+def test_dumps(p):
+    # test dumps
+    res = dumps(p.obj, sequence_as_stream=p.stream)
+    if not p.has_symbols:
+        assert (b'$ion_1_0 ' + p.expected) == res
+    else:
+        # The payload contains a LST. The value comes last, so compare the end bytes.
+        assert p.expected == res[len(res) - len(p.expected):]
 
 
 _ROUNDTRIPS = [


### PR DESCRIPTION
I implemented `simpleion.dumps` as a simple wrapper over `simpleion.dump` using `six.BytesIO` as the file buffer.

I got an error when running existing tests:

    tests/test_vectors.py:328: in <module>
        _basic_params(_T.BAD, _BAD_UTF8_SUBDIR),
    tests/test_vectors.py:199: in _basic_params
        for file in _list_files(directory_path):
    tests/test_vectors.py:174: in _list_files
        for file in listdir(directory_path):
    E   OSError: [Errno 2] No such file or directory: '/path/to/ion-python/vectors/iontestdata/good'

Does it have to do with my change or something I'm missing in my dev environment?

I hope contributions are accepted!