### PR TITLE
Add coverage support via Codacy #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /build
 /dist
 /amazon.ion.egg-info
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,18 @@ python:
   - "3.4"
   - "3.5"
   - "pypy"
+
+matrix:
+  include:
+  - env: COVERAGE=1
+    python: "2.7"
+
 install:
   - "pip install -r requirements.txt"
   - "pip install ."
-script: py.test
+script:
+  - if [ -z $COVERAGE ] ; then
+      py.test;
+    else
+      py.test --cov --cov-report xml && python-codacy-coverage;
+    fi

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,4 @@
+tests:
+
+exclude_dirs:
+  - /tests/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ py==1.4.31
 pytest==2.9.2
 pytest-runner==2.8
 six==1.10.0
+pytest-cov>=2.5,<3.0
+codacy-coverage>=1.3,<2.0


### PR DESCRIPTION
Needs CODACY_PROJECT_TOKEN env var to be added in Travis settings, as per
https://github.com/codacy/python-codacy-coverage#user-content-updating-codacy