### PR TITLE
Binary support loads() and dumps()

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 from datetime import datetime
 from decimal import Decimal
-from io import TextIOBase
+from io import BytesIO, TextIOBase
 from itertools import chain
 
 import six
@@ -372,7 +372,35 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
         event = reader.send(NEXT_EVENT)
 
 
-def loads(fp, encoding='utf-8', cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None,
-          object_pairs_hook=None, use_decimal=None, **kw):
-    """Not yet implemented"""
-    raise IonException("Not yet implemented")
+def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
+          parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, **kw):
+    """Deserialize ``ion_str``, which is a string representation of an Ion object, to a Python object using the
+    conversion table used by load (above).
+
+    Args:
+        fp (str): A string representation of Ion data.
+        catalog (Optional[SymbolTableCatalog]): The catalog to use for resolving symbol table imports.
+        single_value (Optional[True|False]): When True, the data in ``ion_str`` is interpreted as a single Ion value,
+            and will be returned without an enclosing container. If True and there are multiple top-level values in
+            the Ion stream, IonException will be raised. NOTE: this means that when data is dumped using
+            ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
+        encoding: NOT IMPLEMENTED
+        cls: NOT IMPLEMENTED
+        object_hook: NOT IMPLEMENTED
+        parse_float: NOT IMPLEMENTED
+        parse_int: NOT IMPLEMENTED
+        parse_constant: NOT IMPLEMENTED
+        object_pairs_hook: NOT IMPLEMENTED
+        use_decimal: NOT IMPLEMENTED
+        **kw: NOT IMPLEMENTED
+
+    Returns (Any):
+        if single_value is True:
+            A Python object representing a single Ion value.
+        else:
+            A sequence of Python objects representing a stream of Ion values.
+    """
+    ion_buffer = BytesIO(ion_str.encode())
+    return load(ion_buffer, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
+                object_hook=object_hook, parse_float=parse_float, parse_int=parse_int, parse_constant=parse_constant,
+                object_pairs_hook=object_pairs_hook, use_decimal=use_decimal)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -204,16 +204,17 @@ def _dump(obj, writer, field=None):
     writer.send(event)
 
 
-def dumps(obj, imports=None, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True,
+def dumps(obj, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True, check_circular=True,
           allow_nan=True, cls=None, indent=None, separators=None, encoding='utf-8', default=None, use_decimal=True,
           namedtuple_as_object=True, tuple_as_array=True, bigint_as_string=False, sort_keys=False, item_sort_key=None,
           for_json=None, ignore_nan=False, int_as_string_bitcount=None, iterable_as_array=False, **kw):
-    """Serialize ``obj`` as an Ion string, using the conversion table used by ``dump`` (above).
+    """Serialize ``obj`` as Python ``string`` or ``bytes`` object, using the conversion table used by ``dump`` (above).
 
     Args:
         obj (Any): A python object to serialize according to the above table. Any Python object which is neither an
             instance of nor inherits from one of the types in the above table will raise TypeError.
         imports (Optional[Sequence[SymbolTable]]): A sequence of shared symbol tables to be used by by the writer.
+        binary (Optional[True|False]): When True, outputs binary Ion. When false, outputs text Ion.
         sequence_as_stream (Optional[True|False]): When True, if ``obj`` is a sequence, it will be treated as a stream
             of top-level Ion values (i.e. the resulting Ion data will begin with ``obj``'s first element).
             Default: False.
@@ -239,19 +240,22 @@ def dumps(obj, imports=None, sequence_as_stream=False, skipkeys=False, ensure_as
         **kw: NOT IMPLEMENTED
 
     Returns:
-        str: Ion clob representation of ``obj``
+        Union[str|bytes]: The string or binary representation of the data.  if ``binary=True``, this will be a
+            ``bytes`` object, otherwise this will be a ``str`` object (or ``unicode`` in the case of Python 2.x)
     """
     ion_buffer = six.BytesIO()
 
-    dump(obj, ion_buffer, sequence_as_stream=sequence_as_stream, binary=False, skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
+    dump(obj, ion_buffer, sequence_as_stream=sequence_as_stream, binary=binary, skipkeys=skipkeys, ensure_ascii=ensure_ascii, check_circular=check_circular,
          allow_nan=allow_nan, cls=cls, indent=indent, separators=separators, encoding=encoding, default=default,
          use_decimal=use_decimal, namedtuple_as_object=namedtuple_as_object, tuple_as_array=tuple_as_array,
          bigint_as_string=bigint_as_string, sort_keys=sort_keys, item_sort_key=item_sort_key, for_json=for_json,
          ignore_nan=ignore_nan, int_as_string_bitcount=int_as_string_bitcount, iterable_as_array=iterable_as_array)
 
-    ion_str = ion_buffer.getvalue().decode('utf-8')
+    ret_val = ion_buffer.getvalue()
     ion_buffer.close()
-    return ion_str
+    if not binary:
+        ret_val = ret_val.decode('utf-8')
+    return ret_val
 
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
@@ -400,7 +404,14 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
         else:
             A sequence of Python objects representing a stream of Ion values.
     """
-    ion_buffer = BytesIO(ion_str.encode())
+
+    if isinstance(ion_str, six.binary_type):
+        ion_buffer = BytesIO(ion_str)
+    elif isinstance(ion_str, six.text_type):
+        ion_buffer = six.StringIO(ion_str)
+    else:
+        raise TypeError('Unsupported text: %r' % ion_str)
+
     return load(ion_buffer, catalog=catalog, single_value=single_value, encoding=encoding, cls=cls,
                 object_hook=object_hook, parse_float=parse_float, parse_int=parse_int, parse_constant=parse_constant,
                 object_pairs_hook=object_pairs_hook, use_decimal=use_decimal)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -44,10 +44,14 @@ class _Parameter(record('desc', 'obj', 'expected', 'has_symbols', ('stream', Fal
         return self.desc
 
 
-class _Expected:
-    def __init__(self, binary, text):
-        self.binary = [binary]
-        self.text = [text]
+class _Expected(record('binary', 'text')):
+    def __new__(cls, binary, text):
+        return super(_Expected, cls).__new__(cls, (binary,), (text,))
+
+
+def bytes_of(*args, **kwargs):
+    return bytes(bytearray(*args, **kwargs))
+
 
 _SIMPLE_CONTAINER_MAP = {
     IonType.LIST: (
@@ -62,7 +66,7 @@ _SIMPLE_CONTAINER_MAP = {
         (
             [[0], ],
             _Expected(
-                bytearray([
+                bytes_of([
                     0xB0 | 0x01,  # Int value 0 fits in 1 byte.
                     ION_ENCODED_INT_ZERO
                 ]),
@@ -72,7 +76,7 @@ _SIMPLE_CONTAINER_MAP = {
         (
             [IonPyList.from_value(IonType.LIST, [0]), ],
             _Expected(
-                bytearray([
+                bytes_of([
                     0xB0 | 0x01,  # Int value 0 fits in 1 byte.
                     ION_ENCODED_INT_ZERO
                 ]),
@@ -88,7 +92,7 @@ _SIMPLE_CONTAINER_MAP = {
         (
             [IonPyList.from_value(IonType.SEXP, [0]), ],
             _Expected(
-                bytearray([
+                bytes_of([
                     0xC0 | 0x01,  # Int value 0 fits in 1 byte.
                     ION_ENCODED_INT_ZERO
                 ]),
@@ -108,7 +112,7 @@ _SIMPLE_CONTAINER_MAP = {
         (
             [{u'foo': 0}, ],
             _Expected(
-                bytearray([
+                bytes_of([
                     0xDE,  # The lower nibble may vary. It does not indicate actual length unless it's 0.
                     VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
                     VARUINT_END_BYTE | 10,
@@ -120,7 +124,7 @@ _SIMPLE_CONTAINER_MAP = {
         (
             [IonPyDict.from_value(IonType.STRUCT, {u'foo': 0}), ],
             _Expected(
-                bytearray([
+                bytes_of([
                     0xDE,  # The lower nibble may vary. It does not indicate actual length unless it's 0.
                     VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
                     VARUINT_END_BYTE | 10,
@@ -168,9 +172,13 @@ def generate_containers_binary(container_map, preceding_symbols=0):
                 if isinstance(elem, dict) and len(elem) > 0:
                     has_symbols = True
             if has_symbols and preceding_symbols:
+                # we need to make a distinct copy that will contain an altered encoding
+                expecteds = []
                 for expected in expecteds:
+                    expected = bytearray(expected)
                     field_sid = expected[-2] & (~VARUINT_END_BYTE)
                     expected[-2] = VARUINT_END_BYTE | (preceding_symbols + field_sid)
+                    expecteds.append(expected)
             expected = bytearray()
             for e in expecteds:
                 expected.extend(e)
@@ -204,6 +212,54 @@ def generate_annotated_values_binary(scalars_map, container_map):
         )
 
 
+def _assert_symbol_aware_ion_equals(assertion, output):
+    if ion_equals(assertion, output):
+        return True
+    if isinstance(assertion, SymbolToken):
+        expected_token = assertion
+        if assertion.text is None:
+            assert assertion.sid is not None
+            # System symbol IDs are mapped correctly in the text format.
+            token = SYSTEM_SYMBOL_TABLE.get(assertion.sid)
+            assert token is not None  # User symbols with unknown text won't be successfully read.
+            expected_token = token
+        return expected_token == output
+    else:
+        try:
+            return isnan(assertion) and isnan(output)
+        except TypeError:
+            return False
+
+
+def _dump_load_run(p, dumps_func, loads_func, binary):
+    # test dump
+    res = dumps_func(p.obj, binary=binary, sequence_as_stream=p.stream)
+    if not p.has_symbols:
+        if binary:
+            assert (_IVM + p.expected) == res
+        else:
+            assert (b'$ion_1_0 ' + p.expected) == res
+    else:
+        # The payload contains a LST. The value comes last, so compare the end bytes.
+        assert p.expected == res[len(res) - len(p.expected):]
+    # test load
+    res = loads_func(res, single_value=(not p.stream))
+    _assert_symbol_aware_ion_equals(p.obj, res)
+
+
+def _simple_dumps(obj, *args, **kw):
+    buf = BytesIO()
+    dump(obj, buf, *args, **kw)
+    return buf.getvalue()
+
+
+def _simple_loads(data, *args, **kw):
+    buf = BytesIO()
+    buf.write(data)
+    buf.seek(0)
+    return load(buf, *args, **kw)
+
+
 @parametrize(
     *tuple(chain(
         generate_scalars_binary(SIMPLE_SCALARS_MAP_BINARY),
@@ -212,19 +268,18 @@ def generate_annotated_values_binary(scalars_map, container_map):
     ))
 )
 def test_dump_load_binary(p):
-    # test dump
-    out = BytesIO()
-    dump(p.obj, out, binary=True, sequence_as_stream=p.stream)
-    res = out.getvalue()
-    if not p.has_symbols:
-        assert (_IVM + p.expected) == res
-    else:
-        # The payload contains a LST. The value comes last, so compare the end bytes.
-        assert p.expected == res[len(res) - len(p.expected):]
-    # test load
-    out.seek(0)
-    res = load(out, single_value=(not p.stream))
-    assert ion_equals(p.obj, res)
+    _dump_load_run(p, _simple_dumps, _simple_loads, binary=True)
+
+
+@parametrize(
+    *tuple(chain(
+        generate_scalars_binary(SIMPLE_SCALARS_MAP_BINARY),
+        generate_containers_binary(_SIMPLE_CONTAINER_MAP),
+        generate_annotated_values_binary(SIMPLE_SCALARS_MAP_BINARY, _SIMPLE_CONTAINER_MAP),
+    ))
+)
+def test_dumps_loads_binary(p):
+    _dump_load_run(p, dumps, loads, binary=True)
 
 
 def generate_scalars_text(scalars_map):
@@ -276,27 +331,6 @@ def generate_annotated_values_text(scalars_map, container_map):
         )
 
 
-def _assert_symbol_aware_ion_equals(assertion, output):
-    if ion_equals(assertion, output):
-        return True
-    if isinstance(assertion, SymbolToken):
-        expected_token = assertion
-        if assertion.text is None:
-            assert assertion.sid is not None
-            # System symbol IDs are mapped correctly in the text format.
-            token = SYSTEM_SYMBOL_TABLE.get(assertion.sid)
-            assert token is not None  # User symbols with unknown text won't be successfully read.
-            expected_token = token
-        return expected_token == output
-    else:
-        try:
-            return isnan(assertion) and isnan(output)
-        except TypeError:
-            return False
-    if not equals():
-        assert ion_equals(assertion, output)  # Redundant, but provides better error message.
-
-
 @parametrize(
     *tuple(chain(
         generate_scalars_text(SIMPLE_SCALARS_MAP_TEXT),
@@ -305,19 +339,7 @@ def _assert_symbol_aware_ion_equals(assertion, output):
     ))
 )
 def test_dump_load_text(p):
-    # test dump
-    out = BytesIO()
-    dump(p.obj, out, binary=False, sequence_as_stream=p.stream)
-    res = out.getvalue()
-    if not p.has_symbols:
-        assert (b'$ion_1_0 ' + p.expected) == res
-    else:
-        # The payload contains a LST. The value comes last, so compare the end bytes.
-        assert p.expected == res[len(res) - len(p.expected):]
-    # test load
-    out.seek(0)
-    res = load(out, single_value=(not p.stream))
-    _assert_symbol_aware_ion_equals(p.obj, res)
+    _dump_load_run(p, _simple_dumps, _simple_loads, binary=False)
 
 
 @parametrize(
@@ -328,16 +350,12 @@ def test_dump_load_text(p):
     ))
 )
 def test_dumps_loads_text(p):
-    # test dumps
-    dumps_res = dumps(p.obj, sequence_as_stream=p.stream)
-    if not p.has_symbols:
-        assert (b'$ion_1_0 ' + p.expected).decode('utf-8') == dumps_res
-    else:
-        # The payload contains a LST. The value comes last, so compare the end bytes.
-        assert (p.expected).decode('utf-8') == dumps_res[len(dumps_res) - len(p.expected):]
-    # test loads
-    loads_res = loads(dumps_res, single_value=(not p.stream))
-    _assert_symbol_aware_ion_equals(p.obj, loads_res)
+    def dump_func(*args, **kw):
+        sval = dumps(*args, **kw)
+        # encode to UTF-8 bytes for comparisons
+        return sval.encode('UTF-8')
+
+    _dump_load_run(p, dump_func, loads, binary=False)
 
 
 _ROUNDTRIPS = [


### PR DESCRIPTION
Addresses #42 .

Adapts PR #57 to integrate with binary for `loads`/`dumps` and refactors the tests to work with `loads`/`dumps`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
