### PR TITLE
Supply a bit_length function in Python 2.6 that is fully compatible with later versions

### DIFF
--- a/amazon/ion/util.py
+++ b/amazon/ion/util.py
@@ -285,7 +285,9 @@ def _next_code_point(val, val_iter, yield_char=False, to_int=lambda x: x):
 
 if sys.version_info < (2, 7):
     def bit_length(value):
-        return len(bin(value)) - 2
+        if value == 0:
+            return 0
+        return len(bin(abs(value))) - 2
 
     def total_seconds(td):
         return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / 10 ** 6

--- a/amazon/ion/util.py
+++ b/amazon/ion/util.py
@@ -298,5 +298,6 @@ else:
     def total_seconds(td):
         return td.total_seconds()
 
+
 bit_length.__doc__ = 'Returns the bit length of an integer'
 total_seconds.__doc__ = 'Timedelta ``total_seconds`` with backported support in Python 2.6'


### PR DESCRIPTION
Implements one of the suggestions found in the [github issue](https://github.com/apple/foundationdb/pull/1067) that references #69.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
