### PR TITLE
Adds support for Python 3.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: python
-dist: xenial
-sudo: true
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
-  - "pypy"
-  # https://github.com/travis-ci/travis-ci/issues/9542
-  # pypy3 < 6.0.0 fails due to discrepancies with decimal...
-  #- "pypy3"
+matrix:
+  include:
+    - python: "2.6"
+    - python: "2.7"
+    - python: "3.3"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
+    - python: "3.7"
+      dist: xenial
+      sudo: true
+    - python: "pypy"
+    # https://github.com/travis-ci/travis-ci/issues/9542
+    # pypy3 < 6.0.0 fails due to discrepancies with decimal...
+    #- python: "pypy3"
 install:
   - "pip install -r requirements.txt"
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
   - "pypy"
   # https://github.com/travis-ci/travis-ci/issues/9542
   # pypy3 < 6.0.0 fails due to discrepancies with decimal...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+dist: xenial
+sudo: true
 python:
   - "2.6"
   - "2.7"

--- a/README.md
+++ b/README.md
@@ -50,20 +50,20 @@ of [tox](http://tox.readthedocs.io/en/latest/) with [pyenv](https://github.com/y
 Install relevant versions of Python:
 
 ```
-$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 pypy2.7-6.0.0 pypy3.5-6.0.0; do pyenv install $V; done
+$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0; do pyenv install $V; done
 ```
 
 Note that on Mac OS X, you may need to change the `CFLAGS`:
 
 ```
-$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 pypy2.7-6.0.0 pypy3.5-6.0.0; do
+$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0; do
     CFLAGS="-I$(xcrun --show-sdk-path)/usr/include" pyenv install $V; done
 ```
 
 Once you have these installations, add them as a local `pyenv` configuration
 
 ```
-$ pyenv local 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 pypy2.7-6.0.0 pypy3.5-6.0.0
+$ pyenv local 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0
 ```
 
 At the time of this writing, on Mac OS X, you may have problems with `pyenv` and `pypy`.

--- a/amazon/ion/util.py
+++ b/amazon/ion/util.py
@@ -207,7 +207,10 @@ def unicode_iter(val):
     """
     val_iter = iter(val)
     while True:
-        code_point = next(_next_code_point(val, val_iter, to_int=ord))
+        try:
+            code_point = next(_next_code_point(val, val_iter, to_int=ord))
+        except StopIteration:
+            return
         if code_point is None:
             raise ValueError('Unpaired high surrogate at end of Unicode sequence: %r' % val)
         yield code_point
@@ -249,7 +252,10 @@ def _next_code_point(val, val_iter, yield_char=False, to_int=lambda x: x):
             surrogate pair in order to successfully convert the code point back to a unicode character.
         to_int (Optional[callable]): A function to call on each element of val_iter to convert that element to an int.
     """
-    high = next(val_iter)
+    try:
+        high = next(val_iter)
+    except StopIteration:
+        return
     low = None
     code_point = to_int(high)
     if _LOW_SURROGATE_START <= code_point <= _LOW_SURROGATE_END:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,pypy,pypy3
+envlist = py26,py27,py33,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 deps=-rrequirements.txt


### PR DESCRIPTION
*Issue #, if available:*
#71 

*Description of changes:*
[PEP 479](https://www.python.org/dev/peps/pep-0479/) makes an uncaught `StopIteration` within a generator function a `RuntimeError`. When StopIteration is expected within a generator, it may be caught at the source, allowing for a clean return. This change is forward- and backward-compatible.

Note: Travis CI [only supports](https://github.com/travis-ci/travis-ci/issues/9831) Python 3.7 on the Xenial distribution (with sudo enabled).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
