### PR TITLE
Lowers the configured Emax and Emin in test_vectors into the 32-bit range.

### DIFF
--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -68,9 +68,10 @@ _FILE_ENCODINGS[_good_file(u'utf16.ion')] = _ENCODING_UTF16_BE
 _FILE_ENCODINGS[_good_file(u'utf32.ion')] = _ENCODING_UTF32_BE
 
 # Set these Decimal limits arbitrarily high because some test vectors require it. If users need decimals this large,
-# they'll have to do this in their code too.
-getcontext().Emax = 100000000000000000
-getcontext().Emin = -100000000000000000
+# they'll have to do this in their code too. CPython may store these in an ssize_t, so the values should remain in the
+# 32-bit range for compatibility with 32-bit platforms.
+getcontext().Emax = 2147483647
+getcontext().Emin = -2147483648
 getcontext().prec = 100000
 
 


### PR DESCRIPTION
*Issue #, if available:*
#74 

*Description of changes:*
These limits were arbitrarily high. Setting them to the 32-bit max and min is fine, and should allow support for 32-bit platforms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
