### PR TITLE
Adds LICENSE, NOTICE, CHANGES, tests source, and test vectors as data_files in the distribution.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,18 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os
+
 from setuptools import setup, find_packages
+
+
+def find_files(directory, suffix=None):
+    files = []
+    for root, _, filenames in os.walk(directory):
+        for filename in filenames:
+            if not filename.startswith('.') and (suffix is None or filename.endswith(suffix)):
+                files.append(os.path.join(root, filename))
+    return files
 
 
 setup(
@@ -43,4 +54,10 @@ setup(
     tests_require=[
         'pytest',
     ],
+
+    data_files=[
+        ('', ['LICENSE', 'NOTICE', 'CHANGES.md']),
+        ('tests', find_files('tests', '.py')),
+        ('vectors', find_files('vectors'))
+    ]
 )


### PR DESCRIPTION
*Issue #, if available:*
#72 

*Description of changes:*
Results in the following output from `python setup.py sdist`:

```
running sdist
running egg_info
creating amazon.ion.egg-info
writing amazon.ion.egg-info/PKG-INFO
writing dependency_links to amazon.ion.egg-info/dependency_links.txt
writing namespace_packages to amazon.ion.egg-info/namespace_packages.txt
writing requirements to amazon.ion.egg-info/requires.txt
writing top-level names to amazon.ion.egg-info/top_level.txt
writing manifest file 'amazon.ion.egg-info/SOURCES.txt'
reading manifest file 'amazon.ion.egg-info/SOURCES.txt'
writing manifest file 'amazon.ion.egg-info/SOURCES.txt'
running check
creating amazon.ion-0.3.1
creating amazon.ion-0.3.1/amazon
creating amazon.ion-0.3.1/amazon.ion.egg-info
creating amazon.ion-0.3.1/amazon/ion
creating amazon.ion-0.3.1/tests
creating amazon.ion-0.3.1/vectors
creating amazon.ion-0.3.1/vectors/iontestdata
creating amazon.ion-0.3.1/vectors/iontestdata/bad
creating amazon.ion-0.3.1/vectors/iontestdata/bad/timestamp
creating amazon.ion-0.3.1/vectors/iontestdata/bad/timestamp/outOfRange
creating amazon.ion-0.3.1/vectors/iontestdata/bad/utf8
creating amazon.ion-0.3.1/vectors/iontestdata/good
creating amazon.ion-0.3.1/vectors/iontestdata/good/equivs
creating amazon.ion-0.3.1/vectors/iontestdata/good/equivs/utf8
creating amazon.ion-0.3.1/vectors/iontestdata/good/non-equivs
creating amazon.ion-0.3.1/vectors/iontestdata/good/timestamp
creating amazon.ion-0.3.1/vectors/iontestdata/good/timestamp/equivTimeline
copying files to amazon.ion-0.3.1...
copying CHANGES.md -> amazon.ion-0.3.1
copying LICENSE -> amazon.ion-0.3.1
copying NOTICE -> amazon.ion-0.3.1
copying README.md -> amazon.ion-0.3.1
copying setup.cfg -> amazon.ion-0.3.1
copying setup.py -> amazon.ion-0.3.1
copying amazon/__init__.py -> amazon.ion-0.3.1/amazon
copying amazon.ion.egg-info/PKG-INFO -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon.ion.egg-info/SOURCES.txt -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon.ion.egg-info/dependency_links.txt -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon.ion.egg-info/namespace_packages.txt -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon.ion.egg-info/requires.txt -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon.ion.egg-info/top_level.txt -> amazon.ion-0.3.1/amazon.ion.egg-info
copying amazon/ion/__init__.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/core.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/equivalence.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/exceptions.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/reader.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/reader_binary.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/reader_managed.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/reader_text.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/simple_types.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/simpleion.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/symbols.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/util.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer_binary.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer_binary_raw.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer_binary_raw_fields.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer_buffer.py -> amazon.ion-0.3.1/amazon/ion
copying amazon/ion/writer_text.py -> amazon.ion-0.3.1/amazon/ion
copying tests/__init__.py -> amazon.ion-0.3.1/tests
copying tests/event_aliases.py -> amazon.ion-0.3.1/tests
copying tests/reader_util.py -> amazon.ion-0.3.1/tests
copying tests/test_core_iontype.py -> amazon.ion-0.3.1/tests
copying tests/test_equivalence.py -> amazon.ion-0.3.1/tests
copying tests/test_package.py -> amazon.ion-0.3.1/tests
copying tests/test_reader_base.py -> amazon.ion-0.3.1/tests
copying tests/test_reader_binary.py -> amazon.ion-0.3.1/tests
copying tests/test_reader_buffer.py -> amazon.ion-0.3.1/tests
copying tests/test_reader_managed.py -> amazon.ion-0.3.1/tests
copying tests/test_reader_text.py -> amazon.ion-0.3.1/tests
copying tests/test_simple_types.py -> amazon.ion-0.3.1/tests
copying tests/test_simpleion.py -> amazon.ion-0.3.1/tests
copying tests/test_symbols_catalog.py -> amazon.ion-0.3.1/tests
copying tests/test_symbols_table.py -> amazon.ion-0.3.1/tests
copying tests/test_util_enum.py -> amazon.ion-0.3.1/tests
copying tests/test_util_record.py -> amazon.ion-0.3.1/tests
copying tests/test_util_unicode.py -> amazon.ion-0.3.1/tests
copying tests/test_vectors.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_base.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_binary.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_binary_raw.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_binary_raw_fields.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_buffer.py -> amazon.ion-0.3.1/tests
copying tests/test_writer_text.py -> amazon.ion-0.3.1/tests
copying tests/trampoline_util.py -> amazon.ion-0.3.1/tests
copying tests/writer_util.py -> amazon.ion-0.3.1/tests
copying vectors/LICENSE -> amazon.ion-0.3.1/vectors
copying vectors/NOTICE -> amazon.ion-0.3.1/vectors
copying vectors/README.md -> amazon.ion-0.3.1/vectors
copying vectors/iontestdata/bad/README.md -> amazon.ion-0.3.1/vectors/iontestdata/bad
copying vectors/iontestdata/bad/annotationFalse.ion -> amazon.ion-0.3.1/vectors/iontestdata/bad
copying vectors/iontestdata/bad/annotationLengthTooLongContainer.10n -> amazon.ion-0.3.1/vectors/iontestdata/bad
copying vectors/iontestdata/bad/annotationLengthTooLongScalar.10n -> amazon.ion-0.3.1/vectors/iontestdata/bad
```
...[hundreds more test vectors]...
```
copying vectors/iontestdata/good/timestamp/equivTimeline/timestamps.ion -> amazon.ion-0.3.1/vectors/iontestdata/good/timestamp/equivTimeline
Writing amazon.ion-0.3.1/setup.cfg
creating dist
Creating tar archive
removing 'amazon.ion-0.3.1' (and everything under it)
```

Note: `tests` is still not treated as a python package; its files are included as ordinary data files that may be executed by a consumer of the source distribution if they want.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
