### PR TITLE
Keep all key-value pairs when the document has duplicate key names.

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -490,39 +490,39 @@ class Multimap(MutableMapping):
 
     def __init__(self, *args, **kwargs):
         super(Multimap, self).__init__()
-        self.store = {}
+        self.__store = {}
         if args is not None and len(args) > 0:
             for key, value in six.iteritems(args[0]):
-                self.store[key] = MultimapValue(value)
+                self.__store[key] = MultimapValue(value)
 
     def __getitem__(self, key):
-        return self.store[key][len(self.store[key]) - 1]  # Return only one in order not to break clients
+        return self.__store[key][len(self.__store[key]) - 1]  # Return only one in order not to break clients
 
     def __delitem__(self, key):
-        del self.store[key]
+        del self.__store[key]
 
     def __setitem__(self, key, value):
-        self.store[key] = MultimapValue(value)
+        self.__store[key] = MultimapValue(value)
 
     def __len__(self):
-        return sum([len(values) for values in six.itervalues(self.store)])
+        return sum([len(values) for values in six.itervalues(self.__store)])
 
     def __iter__(self):
-        for key in six.iterkeys(self.store):
+        for key in six.iterkeys(self.__store):
             yield key
 
     def add_item(self, key, value):
-        if key in self.store:
-            self.store[key].append(value)
+        if key in self.__store:
+            self.__store[key].append(value)
         else:
             self.__setitem__(key, value)
 
     def get_all_values(self, key):
-        return self.store[key]
+        return self.__store[key]
 
     def iteritems(self):
-        for key in self.store:
-            for value in self.store[key]:
+        for key in self.__store:
+            for value in self.__store[key]:
                 yield (key, value)
 
     def items(self):
@@ -536,25 +536,25 @@ class MultimapValue(MutableSequence):
 
     def __init__(self, *args):
         if args is not None:
-            self.store = [x for x in args]
+            self.__store = [x for x in args]
         else:
-            self.store = []
+            self.__store = []
 
     def insert(self, index, value):
         self.__setitem__(index, value)
 
     def __len__(self):
-        return len(self.store)
+        return len(self.__store)
 
     def __getitem__(self, index):
-        return self.store[index]
+        return self.__store[index]
 
     def __setitem__(self, index, value):
-        self.store.insert(index, value)
+        self.__store.insert(index, value)
 
     def __delitem__(self, index):
-        del self.store[index]
+        del self.__store[index]
 
     def __iter__(self):
-        for x in self.store:
+        for x in self.__store:
             yield x

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -24,12 +24,13 @@ from __future__ import division
 from __future__ import print_function
 
 from decimal import Decimal
+from collections import MutableMapping
 
 import six
 
 from amazon.ion.symbols import SymbolToken
 from .core import TIMESTAMP_PRECISION_FIELD
-from .core import Timestamp, IonEvent, IonType, TIMESTAMP_FRACTION_PRECISION_FIELD, TimestampPrecision, \
+from .core import Multimap, Timestamp, IonEvent, IonType, TIMESTAMP_FRACTION_PRECISION_FIELD, TimestampPrecision, \
     MICROSECOND_PRECISION
 
 
@@ -211,4 +212,5 @@ def is_null(value):
 
 
 IonPyList = _ion_type_for('IonPyList', list)
-IonPyDict = _ion_type_for('IonPyDict', dict)  # TODO support multiple mappings for same field name (iteration only).
+IonPyDict = _ion_type_for('IonPyDict', Multimap)
+

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -362,8 +362,7 @@ def _load(out, reader, end_type=IonEventType.STREAM_END, in_struct=False):
 
     def add(obj):
         if in_struct:
-            # TODO what about duplicate field names?
-            out[event.field_name.text] = obj
+            out.add_item(event.field_name.text, obj)
         else:
             out.append(obj)
 

--- a/tests/test_core_multimap.py
+++ b/tests/test_core_multimap.py
@@ -1,0 +1,63 @@
+from amazon.ion.core import Multimap, record
+import six
+
+from tests import parametrize
+
+
+class _P(record('pairs', 'expected_all_values', 'expected_single_value', 'expected_total_len')):
+    def __str__(self):
+        return self.desc
+
+
+ALL_DATA = _P(
+    pairs=[('a', 1), ('a', 2), ('a', 3), ('a', [4, 5, 6]), ('b', 0), ('c', {'x': 'z', 'r': 's'})],
+    expected_all_values=[('a', [1, 2, 3, [4, 5, 6]]), ('b', [0]), ('c', [{'x': 'z', 'r': 's'}])],
+    expected_single_value=[('a', [4, 5, 6]), ('b', 0), ('c', {'x': 'z', 'r': 's'})],
+    expected_total_len=6
+)
+
+
+def _create_multimap_with_items(pairs):
+    m = Multimap()
+    for pair in pairs:
+        m.add_item(pair[0], pair[1])
+    return m
+
+
+@parametrize(
+    ALL_DATA
+)
+def test_add_item(p):
+    m = _create_multimap_with_items(p.pairs)
+    for expected in p.expected_all_values:
+        assert list([x for x in m.get_all_values(expected[0])]) == expected[1]
+    for expected in p.expected_single_value:
+        assert m[expected[0]] == expected[1]
+    assert p.expected_total_len == len(m)
+
+
+@parametrize(
+    (ALL_DATA, ["a"], 2),
+    (ALL_DATA, ["b"], 5),
+    (ALL_DATA, ["c"], 5),
+    (ALL_DATA, ["a", "b"], 1),
+    (ALL_DATA, ["a", "b", "c"], 0)
+)
+def test_delete_item(item):
+    m = _create_multimap_with_items(item[0].pairs)
+    p, items_to_remove, len_after_removal = item
+    for to_remove in items_to_remove:
+        del m[to_remove]
+    assert len(m) == item[2]
+
+
+@parametrize(
+    {},
+    {"a": 1},
+    {"a": 1, "b": 2, "c": [1, 2, {3: 4}]}
+)
+def test_constructor(d):
+    m = Multimap(d)
+    for k, v in six.iteritems(d):
+        assert m[k] == v
+    assert len(m) == len(d)

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -26,7 +26,7 @@ from pytest import raises
 from amazon.ion.exceptions import IonException
 from amazon.ion.symbols import SymbolToken, SYSTEM_SYMBOL_TABLE
 from amazon.ion.writer_binary import _IVM
-from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo
+from amazon.ion.core import IonType, IonEvent, IonEventType, OffsetTZInfo, Multimap
 from amazon.ion.simple_types import IonPyDict, IonPyText, IonPyList, IonPyNull, IonPyBool, IonPyInt, IonPyFloat, \
     IonPyDecimal, IonPyTimestamp, IonPyBytes, IonPySymbol, _IonNature
 from amazon.ion.equivalence import ion_equals
@@ -170,7 +170,7 @@ def generate_containers_binary(container_map, preceding_symbols=0):
             expecteds = test_tuple[1].binary
             has_symbols = False
             for elem in obj:
-                if isinstance(elem, dict) and len(elem) > 0:
+                if isinstance(elem, (dict, Multimap)) and len(elem) > 0:
                     has_symbols = True
             if has_symbols and preceding_symbols:
                 # we need to make a distinct copy that will contain an altered encoding

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -97,8 +97,6 @@ _SKIP_LIST = (
     _good_file(u'subfieldVarUInt.ion'),  # TODO amzn/ion-python#34
     _good_file(u'subfieldVarUInt32bit.ion'),  # TODO amzn/ion-python#34
     _equivs_file(u'timestampsLargeFractionalPrecision.ion'),  # TODO amzn/ion-python#35
-    _equivs_file(u'structsFieldsRepeatedNames.ion'),  # TODO amzn/ion-python#36
-    _nonequivs_file(u'structs.ion'),  # TODO amzn/ion-python#36
     _nonequivs_file(u'symbolTablesUnknownText.ion'),  # TODO amzn/ion-python#46
     # BINARY:
     _good_file(u'item1.10n'),  # TODO amzn/ion-python#46


### PR DESCRIPTION
Fixes: https://github.com/amzn/ion-python/issues/36

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
