### PR TITLE
Sets Travis CI dist to Xenial and removes 2.6/2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
+dist: xenial
 matrix:
   include:
-    - python: "2.6"
     - python: "2.7"
-    - python: "3.3"
     - python: "3.4"
     - python: "3.5"
     - python: "3.6"


### PR DESCRIPTION
* Python 2.6/3.3 are no longer supported so we should not support it.
* Also `dist: xenial` is now default for Travis CI, but we should be
explicit in our configuration to avoid breakage when the default changes.

Fixes #89


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
