### PR TITLE
Updates Tox/README Python Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
-      dist: xenial
-      sudo: true
     - python: "pypy"
     # https://github.com/travis-ci/travis-ci/issues/9542
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for Python.
 [![Build Status](https://travis-ci.org/amzn/ion-python.svg?branch=master)](https://travis-ci.org/amzn/ion-python)
 [![Documentation Status](https://readthedocs.org/projects/ion-python/badge/?version=latest)](https://ion-python.readthedocs.io/en/latest/?badge=latest)
 
-This package is designed to work with **Python 2.6+** and **Python 3.3+**
+This package is designed to work with **Python 2.7+** and **Python 3.4+**
 
 ## Getting Started
 
@@ -67,25 +67,14 @@ of [tox](http://tox.readthedocs.io/en/latest/) with [pyenv](https://github.com/y
 Install relevant versions of Python:
 
 ```
-$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0; do pyenv install $V; done
-```
-
-Note that on Mac OS X, you may need to change the `CFLAGS`:
-
-```
-$ for V in 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0; do
-    CFLAGS="-I$(xcrun --show-sdk-path)/usr/include" pyenv install $V; done
+$ for V in 2.7.16 3.4.10 3.5.7 3.6.8 3.7.3 pypy2.7-7.1.1 pypy3.6-7.1.1; do pyenv install $V; done
 ```
 
 Once you have these installations, add them as a local `pyenv` configuration
 
 ```
-$ pyenv local 2.6.9 2.7.15 3.3.7 3.4.8 3.5.5 3.6.5 3.7.2 pypy2.7-6.0.0 pypy3.5-6.0.0
+$ pyenv local 2.7.16 3.4.10 3.5.7 3.6.8 3.7.3 pypy2.7-7.1.1 pypy3.6-7.1.1
 ```
-
-At the time of this writing, on Mac OS X, you may have problems with `pyenv` and `pypy`.
-On this platform, it is probably easier to have `pypy` not managed by `pyenv` and install
-and use it directly from `brew`.
 
 Assuming you have `pyenv` properly set up (making sure `pyenv init` is evaluated into your shell),
 you can now run `tox`:

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ $ git submodule update
 ```
 
 ## Development
-It is recommended to use `virtualenv` to create a clean environment to build/test Ion Python.
+It is recommended to use `venv` to create a clean environment to build/test Ion Python.
 
 ```
-$ virtualenv venv
+$ python3 -m venv ./venv
 ...
 $ . venv/bin/activate
 $ pip install -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,py37,pypy,pypy3
+envlist = py27,py34,py35,py36,py37,pypy2,pypy3
 
 [testenv]
 deps=-rrequirements.txt


### PR DESCRIPTION
Updates tox.ini and README Python versions.

* Updates with current tip of versions.
* Removes no longer supported versions to match Travis config..
* Removes extraneous macOS specific commands.
* Fixes tox.ini to correspond to README.
* Minor clean up of Travis CI configuration (pypy3 has some issues
still).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
