### PR TITLE
Remove memoization of events in _IonNature.

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -50,7 +50,6 @@ class _IonNature(object):
         User constructed values will generally not set this field.
     """
     def __init__(self, *args, **kwargs):
-        self.ion_event = None
         self.ion_type = None
         self.ion_annotations = ()
 
@@ -61,7 +60,6 @@ class _IonNature(object):
         """
         args, kwargs = self._to_constructor_args(self)
         value = self.__class__(*args, **kwargs)
-        value.ion_event = None
         value.ion_type = self.ion_type
         value.ion_annotations = self.ion_annotations
         return value
@@ -84,7 +82,6 @@ class _IonNature(object):
             # underlying container will fail.
             args, kwargs = (), {}
         value = cls(*args, **kwargs)
-        value.ion_event = ion_event
         value.ion_type = ion_event.ion_type
         value.ion_annotations = ion_event.annotations
         return value
@@ -103,7 +100,6 @@ class _IonNature(object):
         else:
             args, kwargs = cls._to_constructor_args(value)
             value = cls(*args, **kwargs)
-        value.ion_event = None
         value.ion_type = ion_type
         value.ion_annotations = annotations
         return value
@@ -119,13 +115,11 @@ class _IonNature(object):
         Returns:
             An IonEvent with the properties from this value.
         """
-        if self.ion_event is None:
-            value = self
-            if isinstance(self, IonPyNull):
-                value = None
-            self.ion_event = IonEvent(event_type, ion_type=self.ion_type, value=value, field_name=field_name,
-                                      annotations=self.ion_annotations, depth=depth)
-        return self.ion_event
+        value = self
+        if isinstance(self, IonPyNull):
+            value = None
+        return IonEvent(event_type, ion_type=self.ion_type, value=value, field_name=field_name,
+                                  annotations=self.ion_annotations, depth=depth)
 
 
 def _ion_type_for(name, base_cls):

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -101,11 +101,9 @@ def test_event_types(p):
         output_event = e_scalar(ion_type, event_output)
         assert value_event == output_event
 
-    # assert event_output.ion_event == p.event
     assert event_output.ion_type is ion_type
     assert p.event.annotations == event_output.ion_annotations
 
-    # assert value_output.ion_event is to_event_output
     assert value_output.ion_type is ion_type
     assert p.event.annotations == value_output.ion_annotations
 

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -101,11 +101,11 @@ def test_event_types(p):
         output_event = e_scalar(ion_type, event_output)
         assert value_event == output_event
 
-    assert event_output.ion_event == p.event
+    # assert event_output.ion_event == p.event
     assert event_output.ion_type is ion_type
     assert p.event.annotations == event_output.ion_annotations
 
-    assert value_output.ion_event is to_event_output
+    # assert value_output.ion_event is to_event_output
     assert value_output.ion_type is ion_type
     assert p.event.annotations == value_output.ion_annotations
 

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -546,3 +546,22 @@ def test_pretty_print(p):
         assert actual_pretty_ion_text == exact_text
     for regex_str in regexes:
         assert re.search(regex_str, actual_pretty_ion_text, re.M) is not None
+
+
+# Regression test for ion-python#95
+# Field name of the original test is here.
+def test_struct_field():
+    # pass a dict through simpleion to get a reconstituted dict of Ion values.
+    struct_a = loads(dumps({'dont_remember_my_name': 1}))
+
+    # copy the value of the "dont_remember_my_name" field to a new struct, which is also passed through simpleion
+    mutant = {'new_name': struct_a["dont_remember_my_name"]}
+    print(mutant)
+    struct_b = loads(dumps(mutant))
+
+    print(dumps(struct_b, binary=False))
+
+    # The bug identified in ion-python#95 is that the name of the original field is somehow preserved.
+    # verify this no longer happens
+    assert 'dont_remember_my_name' not in struct_b
+    assert 'new_name' in struct_b

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -548,16 +548,14 @@ def test_pretty_print(p):
         assert re.search(regex_str, actual_pretty_ion_text, re.M) is not None
 
 
-# Regression test for ion-python#95
-# Field name of the original test is here.
+# Regression test for issue #95
 def test_struct_field():
     # pass a dict through simpleion to get a reconstituted dict of Ion values.
     struct_a = loads(dumps({'dont_remember_my_name': 1}))
 
     # copy the value of the "dont_remember_my_name" field to a new struct, which is also passed through simpleion
-    mutant = {'new_name': struct_a["dont_remember_my_name"]}
-    print(mutant)
-    struct_b = loads(dumps(mutant))
+    struct_b = {'new_name': struct_a["dont_remember_my_name"]}
+    struct_c = loads(dumps(struct_b))
 
     print(dumps(struct_b, binary=False))
 

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -557,8 +557,6 @@ def test_struct_field():
     struct_b = {'new_name': struct_a["dont_remember_my_name"]}
     struct_c = loads(dumps(struct_b))
 
-    print(dumps(struct_b, binary=False))
-
     # The bug identified in ion-python#95 is that the name of the original field is somehow preserved.
     # verify this no longer happens
     assert 'dont_remember_my_name' not in struct_b

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -559,5 +559,5 @@ def test_struct_field():
 
     # The bug identified in ion-python#95 is that the name of the original field is somehow preserved.
     # verify this no longer happens
-    assert 'dont_remember_my_name' not in struct_b
-    assert 'new_name' in struct_b
+    assert 'dont_remember_my_name' not in struct_c
+    assert 'new_name' in struct_c

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -551,13 +551,13 @@ def test_pretty_print(p):
 # Regression test for issue #95
 def test_struct_field():
     # pass a dict through simpleion to get a reconstituted dict of Ion values.
-    struct_a = loads(dumps({'dont_remember_my_name': 1}))
+    struct_a = loads(dumps({u'dont_remember_my_name': 1}))
 
     # copy the value of the "dont_remember_my_name" field to a new struct, which is also passed through simpleion
-    struct_b = {'new_name': struct_a["dont_remember_my_name"]}
+    struct_b = {u'new_name': struct_a[u"dont_remember_my_name"]}
     struct_c = loads(dumps(struct_b))
 
     # The bug identified in ion-python#95 is that the name of the original field is somehow preserved.
     # verify this no longer happens
-    assert 'dont_remember_my_name' not in struct_c
-    assert 'new_name' in struct_c
+    assert u'dont_remember_my_name' not in struct_c
+    assert u'new_name' in struct_c


### PR DESCRIPTION
This memoization was causing #95 because the `IonEvent.field_name` field
was being used when writing out struct fields instead of the key of the
field within the `IonPyDict`.  This meant that field with a value that
originated from another `IonPyDict` would retain field name from the original
`IonPyDict` when it was written out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
