### PR TITLE
Support timestamps with more than 6 digits of fractional precision

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -108,15 +108,12 @@ def scale_to_precision(fractional_seconds, fractional_precision):
     """Scales the ```fractional_seconds``` attribute by -```fractional_precision```.
 
     Args:
-        fractional_seconds (int): The numerical value to scale.
+        fractional_seconds (Decimal): The numerical value to scale.
         fractional_precision (int): The negative of this numerical value to scale ```fractional_seconds``` by.
     Returns:
         Decimal: The scaled value.
     """
-    fractional_seconds = Decimal(str(fractional_seconds)[:fractional_precision])
-    for i in range(fractional_precision):
-        fractional_seconds = Decimal(fractional_seconds) / 10
-    return fractional_seconds
+    return Decimal(fractional_seconds) * Decimal(Decimal(10) ** Decimal(-fractional_precision))
 
 
 class IonEvent(record(

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -124,7 +124,7 @@ def _fractional_seconds_to_microseconds(fractional_seconds):
     Returns:
         int: The scaled value.
     """
-    integral_fractional_seconds = fractional_seconds * (10 ** MICROSECOND_PRECISION)
+    integral_fractional_seconds = fractional_seconds * BASE_TEN_MICROSECOND_PRECISION_EXPONENTIATION
     return int(integral_fractional_seconds)
 
 
@@ -400,6 +400,7 @@ TIMESTAMP_PRECISION_FIELD = 'precision'
 TIMESTAMP_FRACTION_PRECISION_FIELD = 'fractional_precision'
 TIMESTAMP_FRACTIONAL_SECONDS_FIELD = 'fractional_seconds'
 MICROSECOND_PRECISION = 6
+BASE_TEN_MICROSECOND_PRECISION_EXPONENTIATION = 10 ** MICROSECOND_PRECISION
 
 
 class Timestamp(datetime):
@@ -480,6 +481,9 @@ class Timestamp(datetime):
         if fractional_seconds is not None and (fractional_precision is not None or datetime_microseconds is not None):
             raise ValueError('fractional_seconds cannot be specified '
                              'when fractional_precision or microseconds are not None.')
+
+        if fractional_precision is not None and datetime_microseconds is None:
+            raise ValueError('datetime_microseconds cannot be None while fractional_precision is not None.')
 
         if fractional_seconds is not None:
             fractional_precision = min(fractional_seconds.as_tuple().exponent * -1, MICROSECOND_PRECISION)

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -434,6 +434,10 @@ class Timestamp(datetime):
             args = tuple(lst)
             fractional_precision = min(fraction_seconds_length, MICROSECOND_PRECISION)
 
+        if args[6] is None:
+            lst = list(args)
+            lst[6] = 0
+            args = tuple(lst)
         instance = super(Timestamp, cls).__new__(cls, *args, **kwargs)
         setattr(instance, TIMESTAMP_PRECISION_FIELD, precision)
         setattr(instance, TIMESTAMP_FRACTION_PRECISION_FIELD, fractional_precision)
@@ -507,7 +511,6 @@ def timestamp(year, month=1, day=1,
         if fractional_precision is None:
             fractional_precision = MICROSECOND_PRECISION
     else:
-        microsecond = 0
         if fractional_precision is not None:
             raise ValueError('Cannot have fractional precision without a fractional component.')
     return Timestamp(

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -460,7 +460,16 @@ class Timestamp(datetime):
 
             if DATETIME_MICROSECONDS is not None and fractional_precision is not None \
                     and fractional_seconds is None:
-                fractional_seconds = scale_to_precision(DATETIME_MICROSECONDS, MICROSECOND_PRECISION)
+                if fractional_precision > 6:
+                    fractional_seconds = scale_to_precision(DATETIME_MICROSECONDS, fractional_precision)
+                    lst = list(args)
+                    integral_fractional_seconds = fractional_seconds * (10 ** MICROSECOND_PRECISION)
+                    lst[MICROSECOND_ARGUMENT_INDEX] = Decimal(integral_fractional_seconds).quantize(
+                        MICROSECOND_PRECISION,
+                        rounding="ROUND_DOWN")
+                    args = tuple(lst)
+                else:
+                    fractional_seconds = scale_to_precision(DATETIME_MICROSECONDS, MICROSECOND_PRECISION)
 
             if DATETIME_MICROSECONDS is None and fractional_seconds is not None:
                 lst = list(args)

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -144,7 +144,7 @@ class IonEvent(record(
                 # Special case for timestamps to capture equivalence over precision.
                 self_precision = getattr(self.value, TIMESTAMP_PRECISION_FIELD, None)
                 other_precision = getattr(other.value, TIMESTAMP_PRECISION_FIELD, None)
-                self_fractional_units = getattr(other.value, FRACTIONAL_UNITS, None)
+                self_fractional_seconds = getattr(other.value, FRACTIONAL_SECONDS, None)
                 if self_precision != other_precision \
                         and not ((self_precision is None and other_precision is TimestampPrecision.SECOND) or
                                      (self_precision is TimestampPrecision.SECOND and other_precision is None)):
@@ -367,7 +367,7 @@ class TimestampPrecision(Enum):
 
 TIMESTAMP_PRECISION_FIELD = 'precision'
 TIMESTAMP_FRACTION_PRECISION_FIELD = 'fractional_precision'
-FRACTIONAL_UNITS = 'fractional_units'
+FRACTIONAL_SECONDS = 'fractional_seconds'
 MICROSECOND_PRECISION = 6
 
 
@@ -377,12 +377,12 @@ class Timestamp(datetime):
     Notes:
         The ``precision`` field is passed as a keyword argument of the same name.
     """
-    __slots__ = [TIMESTAMP_PRECISION_FIELD, TIMESTAMP_FRACTION_PRECISION_FIELD, FRACTIONAL_UNITS]
+    __slots__ = [TIMESTAMP_PRECISION_FIELD, TIMESTAMP_FRACTION_PRECISION_FIELD, FRACTIONAL_SECONDS]
 
     def __new__(cls, *args, **kwargs):
         precision = None
         fractional_precision = None
-        fractional_units = None
+        fractional_seconds = None
         if TIMESTAMP_PRECISION_FIELD in kwargs:
             precision = kwargs.get(TIMESTAMP_PRECISION_FIELD)
             # Make sure we mask this before we construct the datetime.
@@ -391,14 +391,14 @@ class Timestamp(datetime):
             fractional_precision = kwargs.get(TIMESTAMP_FRACTION_PRECISION_FIELD)
             # Make sure we mask this before we construct the datetime.
             del kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD]
-        if FRACTIONAL_UNITS in kwargs:
-            fractional_units = kwargs.get(FRACTIONAL_UNITS)
-            del kwargs[FRACTIONAL_UNITS]
+        if FRACTIONAL_SECONDS in kwargs:
+            fractional_seconds = kwargs.get(FRACTIONAL_SECONDS)
+            del kwargs[FRACTIONAL_SECONDS]
 
         instance = super(Timestamp, cls).__new__(cls, *args, **kwargs)
         setattr(instance, TIMESTAMP_PRECISION_FIELD, precision)
         setattr(instance, TIMESTAMP_FRACTION_PRECISION_FIELD, fractional_precision)
-        setattr(instance, FRACTIONAL_UNITS, fractional_units)
+        setattr(instance, FRACTIONAL_SECONDS, fractional_seconds)
 
         return instance
 
@@ -440,14 +440,14 @@ class Timestamp(datetime):
 def timestamp(year, month=1, day=1,
               hour=0, minute=0, second=0, microsecond=None,
               off_hours=None, off_minutes=None,
-              precision=None, fractional_precision=None, fractional_units=None):
+              precision=None, fractional_precision=None, fractional_seconds=None):
     """Shorthand for the :class:`Timestamp` constructor.
 
     Specifically, converts ``off_hours`` and ``off_minutes`` parameters to a suitable
     :class:`OffsetTZInfo` instance.
     """
     delta = None
-    fractional_units_to_pass = None
+    fractional_seconds_to_pass = None
     if off_hours is not None:
         if off_hours < -23 or off_hours > 23:
             raise ValueError('Hour offset %d is out of required range -23..23.' % (off_hours,))
@@ -475,13 +475,13 @@ def timestamp(year, month=1, day=1,
 
     if fractional_precision is not None and fractional_precision > MICROSECOND_PRECISION:
         diff = fractional_precision - MICROSECOND_PRECISION
-        fractional_units_to_pass = round(microsecond / (10 ** diff))
+        fractional_seconds_to_pass = round(microsecond / (10 ** diff))
     else:
-        fractional_units_to_pass = microsecond
+        fractional_seconds_to_pass = microsecond
     return Timestamp(
         year, month, day,
-        hour, minute, second, fractional_units_to_pass,
-        tz, precision=precision, fractional_precision=fractional_precision, fractional_units=microsecond
+        hour, minute, second, fractional_seconds_to_pass,
+        tz, precision=precision, fractional_precision=fractional_precision, fractional_seconds=microsecond
     )
 
 

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -476,6 +476,8 @@ def timestamp(year, month=1, day=1,
     if fractional_precision is not None and fractional_precision > MICROSECOND_PRECISION:
         diff = fractional_precision - MICROSECOND_PRECISION
         fractional_seconds_to_pass = round(microsecond / (10 ** diff))
+        if fractional_seconds_to_pass > 999999:
+            fractional_seconds_to_pass = int(str(microsecond)[0:MICROSECOND_PRECISION])
     else:
         fractional_seconds_to_pass = microsecond
     return Timestamp(

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -470,9 +470,8 @@ class Timestamp(datetime):
 
             if DATETIME_MICROSECONDS is None and fractional_seconds is not None:
                 lst = list(args)
-                integral_fractional_seconds = fractional_seconds * (10**MICROSECOND_PRECISION)
-                lst[MICROSECOND_ARGUMENT_INDEX] = Decimal(integral_fractional_seconds).quantize(MICROSECOND_PRECISION,
-                                                                                                rounding="ROUND_DOWN")
+                integral_fractional_seconds = fractional_seconds * (10 ** MICROSECOND_PRECISION)
+                lst[MICROSECOND_ARGUMENT_INDEX] = int(integral_fractional_seconds)
                 args = tuple(lst)
                 DATETIME_MICROSECONDS = args[MICROSECOND_ARGUMENT_INDEX]
 

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -414,11 +414,12 @@ class Timestamp(datetime):
             created from the value of microsecond and truncated to fractional_precision.
 
             - If fractional_seconds is specified but microsecond is not, microsecond is set
-            to the value of fractional_seconds scaled up to microseconds magnitude and fractional_precision is set to
-            the minimum of the precision of fractional_seconds and MICROSECOND_PRECISION.
+            to the value of fractional_seconds scaled up to microseconds magnitude.
 
-            - A ValueError when both microsecond and fractional_seconds are specified, but their values are not
-            equivalent.
+            - A ValueError is raised when both microsecond and fractional_seconds are specified, but their values are
+            not equivalent.
+
+            - A ValueError is raised when fractional_seconds is specified, but fractional_precision is not.
     """
     __slots__ = [TIMESTAMP_PRECISION_FIELD, TIMESTAMP_FRACTION_PRECISION_FIELD, TIMESTAMP_FRACTIONAL_SECONDS_FIELD]
 
@@ -453,6 +454,9 @@ class Timestamp(datetime):
                     and fractional_seconds is not None:
                 if scale_to_precision(DATETIME_MICROSECONDS, fractional_precision) != fractional_seconds:
                     raise ValueError('Microseconds and fractional seconds are not equivalent.')
+
+            if fractional_seconds is not None and fractional_precision is None:
+                raise ValueError('Fractional precision cannot be None while fractional seconds is not None.')
 
             if DATETIME_MICROSECONDS is not None and fractional_precision is not None \
                     and fractional_seconds is None:

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -426,7 +426,6 @@ class Timestamp(datetime):
         precision = None
         fractional_precision = None
         fractional_seconds = None
-        print(len(args))
         MICROSECOND_ARGUMENT_INDEX = 6
         DATETIME_MICROSECONDS = None
         if len(args) > 6:
@@ -450,9 +449,6 @@ class Timestamp(datetime):
             # Make sure we mask this before we construct the datetime.
             del kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD]
         if len(args) > 6:
-            if DATETIME_MICROSECONDS is not None and fractional_precision is None:
-                raise ValueError('Fractional precision cannot be None while microsecond is not None.')
-
             if DATETIME_MICROSECONDS is not None and fractional_precision is not None \
                     and fractional_seconds is not None:
                 if scale_to_precision(DATETIME_MICROSECONDS, fractional_precision) != fractional_seconds:

--- a/amazon/ion/equivalence.py
+++ b/amazon/ion/equivalence.py
@@ -172,7 +172,8 @@ def _timestamps_eq(a, b):
         if isinstance(a, Timestamp):
             if isinstance(b, Timestamp):
                 # Both operands declare their precisions. They are only equivalent if their precisions are the same.
-                if a.precision is b.precision and a.fractional_precision is b.fractional_precision:
+                if a.precision is b.precision and a.fractional_precision is b.fractional_precision \
+                        and a.fractional_seconds == b.fractional_seconds:
                     break
                 return False
             elif a.precision is not TimestampPrecision.SECOND or a.fractional_precision != MICROSECOND_PRECISION:

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -700,6 +700,7 @@ def _timestamp_factory(data):
 
         if buf.tell() == end:
             fraction = None
+            fraction_precison = None
         else:
             fraction = _parse_decimal(buf)
             if fraction < 0 or fraction >= 1:
@@ -708,12 +709,13 @@ def _timestamp_factory(data):
             fraction_exponent = fraction.as_tuple().exponent
             if fraction == 0 and fraction_exponent > -1:
                 fraction = None
-
+            fraction_precison = -1 * fraction_exponent
+        # print(fraction_precison)
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
             hour, minute, second, None,
             tz,
-            precision=precision, fractional_precision=None, fractional_seconds=fraction
+            precision=precision, fractional_precision=fraction_precison, fractional_seconds=fraction
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -721,6 +721,8 @@ def _timestamp_factory(data):
         if fractional_precision is not None and fractional_precision > MICROSECOND_PRECISION:
             diff = fractional_precision - MICROSECOND_PRECISION
             fractional_seconds_to_pass = round(microsecond / (10 ** diff))
+            if fractional_seconds_to_pass > 999999:
+                fractional_seconds_to_pass = int(str(microsecond)[0:MICROSECOND_PRECISION])
         else:
             fractional_seconds_to_pass = microsecond
 

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -714,15 +714,21 @@ def _timestamp_factory(data):
             else:
                 fractional_precision = -1 * fraction_exponent
                 if fractional_precision > MICROSECOND_PRECISION:
-                    raise IonException(
-                        'Timestamp has a fractional component %s with greater than microsecond precision.' % fraction)
-                microsecond = fraction.scaleb(MICROSECOND_PRECISION).to_integral_value()
+                    microsecond = fraction.scaleb(fractional_precision).to_integral_value()
+                else:
+                    microsecond = fraction.scaleb(MICROSECOND_PRECISION).to_integral_value()
+
+        if fractional_precision is not None and fractional_precision > MICROSECOND_PRECISION:
+            diff = fractional_precision - MICROSECOND_PRECISION
+            microseconds_to_pass = round(microsecond / (10 ** diff))
+        else:
+            microseconds_to_pass = microsecond
 
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
-            hour, minute, second, microsecond,
+            hour, minute, second, microseconds_to_pass,
             tz,
-            precision=precision, fractional_precision=fractional_precision
+            precision=precision, fractional_precision=fractional_precision, fractional_units=microsecond
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -661,7 +661,6 @@ def _timestamp_factory(data):
     def parse_timestamp():
         end = len(data)
         buf = BytesIO(data)
-        fraction = 0
 
         precision = TimestampPrecision.YEAR
         off_sign, off_value = _parse_var_int_components(buf, signed=True)
@@ -715,15 +714,15 @@ def _timestamp_factory(data):
             else:
                 fractional_precision = -1 * fraction_exponent
                 if fractional_precision > MICROSECOND_PRECISION:
-                    fraction = fraction.scaleb(fractional_precision).to_integral_value()
+                    microsecond = fraction.scaleb(fractional_precision).to_integral_value()
                 else:
-                    fraction = fraction.scaleb(MICROSECOND_PRECISION).to_integral_value()
+                    microsecond = fraction.scaleb(MICROSECOND_PRECISION).to_integral_value()
 
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
             hour, minute, second, None,
             tz,
-            precision=precision, fractional_precision=None, fractional_seconds=fraction
+            precision=precision, fractional_precision=None, fractional_seconds=microsecond
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -700,7 +700,6 @@ def _timestamp_factory(data):
 
         if buf.tell() == end:
             fraction = None
-            fraction_precision = None
         else:
             fraction = _parse_decimal(buf)
             if fraction < 0 or fraction >= 1:
@@ -709,14 +708,12 @@ def _timestamp_factory(data):
             fraction_exponent = fraction.as_tuple().exponent
             if fraction == 0 and fraction_exponent > -1:
                 fraction = None
-                fraction_precision = None
-            else:
-                fraction_precision = -1 * fraction_exponent
+
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
             hour, minute, second, None,
             tz,
-            precision=precision, fractional_precision=fraction_precision, fractional_seconds=fraction
+            precision=precision, fractional_precision=None, fractional_seconds=fraction
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -700,7 +700,7 @@ def _timestamp_factory(data):
 
         if buf.tell() == end:
             fraction = None
-            fraction_precison = None
+            fraction_precision = None
         else:
             fraction = _parse_decimal(buf)
             if fraction < 0 or fraction >= 1:
@@ -709,13 +709,14 @@ def _timestamp_factory(data):
             fraction_exponent = fraction.as_tuple().exponent
             if fraction == 0 and fraction_exponent > -1:
                 fraction = None
-            fraction_precison = -1 * fraction_exponent
-        # print(fraction_precison)
+                fraction_precision = None
+            else:
+                fraction_precision = -1 * fraction_exponent
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
             hour, minute, second, None,
             tz,
-            precision=precision, fractional_precision=fraction_precison, fractional_seconds=fraction
+            precision=precision, fractional_precision=fraction_precision, fractional_seconds=fraction
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -707,6 +707,7 @@ def _timestamp_factory(data):
                     'Timestamp has a fractional component out of bounds: %s' % fraction)
             fraction_exponent = fraction.as_tuple().exponent
             if fraction == 0 and fraction_exponent > -1:
+                # According to the spec, fractions with coefficients of zero and exponents >= zero are ignored.
                 fraction = None
 
         return Timestamp.adjust_from_utc_fields(

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -720,15 +720,15 @@ def _timestamp_factory(data):
 
         if fractional_precision is not None and fractional_precision > MICROSECOND_PRECISION:
             diff = fractional_precision - MICROSECOND_PRECISION
-            microseconds_to_pass = round(microsecond / (10 ** diff))
+            fractional_seconds_to_pass = round(microsecond / (10 ** diff))
         else:
-            microseconds_to_pass = microsecond
+            fractional_seconds_to_pass = microsecond
 
         return Timestamp.adjust_from_utc_fields(
             year, month, day,
-            hour, minute, second, microseconds_to_pass,
+            hour, minute, second, fractional_seconds_to_pass,
             tz,
-            precision=precision, fractional_precision=fractional_precision, fractional_units=microsecond
+            precision=precision, fractional_precision=fractional_precision, fractional_seconds=microsecond
         )
 
     return parse_timestamp

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -26,7 +26,7 @@ import six
 import sys
 
 from amazon.ion.core import Transition, ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, IonType, IonEvent, \
-    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, MICROSECOND_PRECISION
+    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, scale_to_precision
 from amazon.ion.exceptions import IonException
 from amazon.ion.reader import BufferQueue, reader_trampoline, ReadEventType, safe_unichr, CodePointArray, CodePoint, \
     _NARROW_BUILD
@@ -873,7 +873,7 @@ def _parse_timestamp(tokens):
         precision = TimestampPrecision.YEAR
         off_hour = tokens[_TimestampState.OFF_HOUR]
         off_minutes = tokens[_TimestampState.OFF_MINUTE]
-        microsecond = None
+        fraction = None
         fraction_digits = None
         if off_hour is not None:
             assert off_minutes is not None
@@ -927,12 +927,13 @@ def _parse_timestamp(tokens):
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
                 fraction_digits = len(fraction)
-                microsecond = int(fraction)
+                fraction = int(fraction)
+                fraction = scale_to_precision(fraction, fraction_digits)
         return timestamp(
             year, month, day,
             hour, minute, second, None,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=None, fractional_seconds=microsecond
+            precision=precision, fractional_precision=None, fractional_seconds=fraction
         )
     return parse
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -927,23 +927,12 @@ def _parse_timestamp(tokens):
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
                 fraction_digits = len(fraction)
-                if fraction_digits > MICROSECOND_PRECISION:
-                    has_unnecessary_padding = True
-                    for digit in fraction[MICROSECOND_PRECISION:]:
-                        if digit != _ZERO:
-                            has_unnecessary_padding = False
-                            break
-                    if has_unnecessary_padding:
-                        fraction_digits = MICROSECOND_PRECISION
-                        fraction = fraction[0:MICROSECOND_PRECISION]
-                else:
-                    fraction.extend(_ZEROS[MICROSECOND_PRECISION - fraction_digits])
                 microsecond = int(fraction)
         return timestamp(
             year, month, day,
-            hour, minute, second, microsecond,
+            hour, minute, second, None,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=fraction_digits, fractional_seconds=microsecond
+            precision=precision, fractional_precision=None, fractional_seconds=microsecond
         )
     return parse
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -927,10 +927,8 @@ def _parse_timestamp(tokens):
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
                 fraction_digits = len(fraction)
-                # print(fraction)
                 fraction = int(fraction)
                 fraction = scale_to_precision(fraction, fraction_digits)
-        # print(fraction_digits)
         return timestamp(
             year, month, day,
             hour, minute, second, None,

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -928,12 +928,14 @@ def _parse_timestamp(tokens):
             if fraction is not None:
                 fraction_digits = len(fraction)
                 if fraction_digits > MICROSECOND_PRECISION:
+                    has_unnecessary_padding = True
                     for digit in fraction[MICROSECOND_PRECISION:]:
                         if digit != _ZERO:
-                            raise ValueError('Only six significant digits supported in timestamp fractional. Found %s.'
-                                             % (fraction,))
-                    fraction_digits = MICROSECOND_PRECISION
-                    fraction = fraction[0:MICROSECOND_PRECISION]
+                            has_unnecessary_padding = False
+                            break;
+                    if has_unnecessary_padding:
+                        fraction_digits = MICROSECOND_PRECISION
+                        fraction = fraction[0:MICROSECOND_PRECISION]
                 else:
                     fraction.extend(_ZEROS[MICROSECOND_PRECISION - fraction_digits])
                 microsecond = int(fraction)
@@ -941,7 +943,7 @@ def _parse_timestamp(tokens):
             year, month, day,
             hour, minute, second, microsecond,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=fraction_digits
+            precision=precision, fractional_precision=fraction_digits, fractional_units=microsecond
         )
     return parse
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -26,7 +26,7 @@ import six
 import sys
 
 from amazon.ion.core import Transition, ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, IonType, IonEvent, \
-    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, scale_to_precision
+    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, _scale_to_precision
 from amazon.ion.exceptions import IonException
 from amazon.ion.reader import BufferQueue, reader_trampoline, ReadEventType, safe_unichr, CodePointArray, CodePoint, \
     _NARROW_BUILD
@@ -928,12 +928,12 @@ def _parse_timestamp(tokens):
             if fraction is not None:
                 fraction_digits = len(fraction)
                 fraction = int(fraction)
-                fraction = scale_to_precision(fraction, fraction_digits)
+                fraction = _scale_to_precision(fraction, fraction_digits)
         return timestamp(
             year, month, day,
             hour, minute, second, None,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=fraction_digits, fractional_seconds=fraction
+            precision=precision, fractional_precision=None, fractional_seconds=fraction
         )
     return parse
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -932,7 +932,7 @@ def _parse_timestamp(tokens):
                     for digit in fraction[MICROSECOND_PRECISION:]:
                         if digit != _ZERO:
                             has_unnecessary_padding = False
-                            break;
+                            break
                     if has_unnecessary_padding:
                         fraction_digits = MICROSECOND_PRECISION
                         fraction = fraction[0:MICROSECOND_PRECISION]

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -927,13 +927,15 @@ def _parse_timestamp(tokens):
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
                 fraction_digits = len(fraction)
+                # print(fraction)
                 fraction = int(fraction)
                 fraction = scale_to_precision(fraction, fraction_digits)
+        # print(fraction_digits)
         return timestamp(
             year, month, day,
             hour, minute, second, None,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=None, fractional_seconds=fraction
+            precision=precision, fractional_precision=fraction_digits, fractional_seconds=fraction
         )
     return parse
 

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -943,7 +943,7 @@ def _parse_timestamp(tokens):
             year, month, day,
             hour, minute, second, microsecond,
             off_hour, off_minutes,
-            precision=precision, fractional_precision=fraction_digits, fractional_units=microsecond
+            precision=precision, fractional_precision=fraction_digits, fractional_seconds=microsecond
         )
     return parse
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -164,33 +164,20 @@ class IonPyTimestamp(Timestamp, _IonNature):
 
     @staticmethod
     def _to_constructor_args(ts):
-        fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD, None)
+        try:
+            fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD)
+        except AttributeError:
+            fractional_precision = MICROSECOND_PRECISION
         fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
         precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, TimestampPrecision.SECOND)
-        if fractional_seconds is None:
-            args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
-        else:
+        if fractional_seconds is not None:
             args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
             fractional_precision = None
+        else:
+            args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
         kwargs = {TIMESTAMP_PRECISION_FIELD: precision, TIMESTAMP_FRACTION_PRECISION_FIELD: fractional_precision,
                   TIMESTAMP_FRACTIONAL_SECONDS_FIELD: fractional_seconds}
 
-        # fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
-        # if fractional_seconds is None:
-        #     args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
-        # else:
-        #     args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
-        # kwargs = {}
-        # precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
-        # if precision is None:
-        #     precision = TimestampPrecision.SECOND
-        # kwargs[TIMESTAMP_PRECISION_FIELD] = precision
-        # try:
-        #     fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD)
-        # except AttributeError:
-        #     fractional_precision = MICROSECOND_PRECISION
-        # kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        # kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -175,7 +175,7 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD)
+        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
         kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -31,7 +31,7 @@ import six
 from amazon.ion.symbols import SymbolToken
 from .core import TIMESTAMP_PRECISION_FIELD
 from .core import Multimap, Timestamp, IonEvent, IonType, TIMESTAMP_FRACTION_PRECISION_FIELD, TimestampPrecision, \
-    MICROSECOND_PRECISION, FRACTIONAL_SECONDS
+    MICROSECOND_PRECISION, TIMESTAMP_FRACTIONAL_SECONDS_FIELD
 
 
 class _IonNature(object):
@@ -175,8 +175,8 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        fractional_seconds = getattr(ts, FRACTIONAL_SECONDS, ts.microsecond)
-        kwargs[FRACTIONAL_SECONDS] = fractional_seconds
+        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, ts.microsecond)
+        kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -164,22 +164,33 @@ class IonPyTimestamp(Timestamp, _IonNature):
 
     @staticmethod
     def _to_constructor_args(ts):
+        fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD, None)
         fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
+        precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, TimestampPrecision.SECOND)
         if fractional_seconds is None:
             args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
         else:
             args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
-        kwargs = {}
-        precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
-        if precision is None:
-            precision = TimestampPrecision.SECOND
-        kwargs[TIMESTAMP_PRECISION_FIELD] = precision
-        try:
-            fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD)
-        except AttributeError:
-            fractional_precision = MICROSECOND_PRECISION
-        kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
+            fractional_precision = None
+        kwargs = {TIMESTAMP_PRECISION_FIELD: precision, TIMESTAMP_FRACTION_PRECISION_FIELD: fractional_precision,
+                  TIMESTAMP_FRACTIONAL_SECONDS_FIELD: fractional_seconds}
+
+        # fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
+        # if fractional_seconds is None:
+        #     args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
+        # else:
+        #     args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
+        # kwargs = {}
+        # precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
+        # if precision is None:
+        #     precision = TimestampPrecision.SECOND
+        # kwargs[TIMESTAMP_PRECISION_FIELD] = precision
+        # try:
+        #     fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD)
+        # except AttributeError:
+        #     fractional_precision = MICROSECOND_PRECISION
+        # kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
+        # kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -31,7 +31,7 @@ import six
 from amazon.ion.symbols import SymbolToken
 from .core import TIMESTAMP_PRECISION_FIELD
 from .core import Multimap, Timestamp, IonEvent, IonType, TIMESTAMP_FRACTION_PRECISION_FIELD, TimestampPrecision, \
-    MICROSECOND_PRECISION, FRACTIONAL_UNITS
+    MICROSECOND_PRECISION, FRACTIONAL_SECONDS
 
 
 class _IonNature(object):
@@ -175,8 +175,8 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        fractional_units = getattr(ts, FRACTIONAL_UNITS, ts.microsecond)
-        kwargs[FRACTIONAL_UNITS] = fractional_units
+        fractional_seconds = getattr(ts, FRACTIONAL_SECONDS, ts.microsecond)
+        kwargs[FRACTIONAL_SECONDS] = fractional_seconds
         return args, kwargs
 
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -164,7 +164,7 @@ class IonPyTimestamp(Timestamp, _IonNature):
 
     @staticmethod
     def _to_constructor_args(ts):
-        args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
+        args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
         kwargs = {}
         precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
         if precision is None:

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -164,7 +164,11 @@ class IonPyTimestamp(Timestamp, _IonNature):
 
     @staticmethod
     def _to_constructor_args(ts):
-        args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
+        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
+        if fractional_seconds is None:
+            args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
+        else:
+            args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
         kwargs = {}
         precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, None)
         if precision is None:
@@ -175,7 +179,6 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
         kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -31,7 +31,7 @@ import six
 from amazon.ion.symbols import SymbolToken
 from .core import TIMESTAMP_PRECISION_FIELD
 from .core import Multimap, Timestamp, IonEvent, IonType, TIMESTAMP_FRACTION_PRECISION_FIELD, TimestampPrecision, \
-    MICROSECOND_PRECISION
+    MICROSECOND_PRECISION, FRACTIONAL_UNITS
 
 
 class _IonNature(object):
@@ -175,6 +175,8 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
+        fractional_units = getattr(ts, FRACTIONAL_UNITS, ts.microsecond)
+        kwargs[FRACTIONAL_UNITS] = fractional_units
         return args, kwargs
 
 

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -175,7 +175,7 @@ class IonPyTimestamp(Timestamp, _IonNature):
         except AttributeError:
             fractional_precision = MICROSECOND_PRECISION
         kwargs[TIMESTAMP_FRACTION_PRECISION_FIELD] = fractional_precision
-        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, ts.microsecond)
+        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD)
         kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD] = fractional_seconds
         return args, kwargs
 

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -253,7 +253,7 @@ def _serialize_timestamp(ion_event):
         length += _write_varuint(value_buf, dt.minute)
     if precision.includes_second:
         length += _write_varuint(value_buf, dt.second)
-        coefficient_fraction_seconds = getattr(ion_event.value, TIMESTAMP_FRACTIONAL_SECONDS_FIELD)
+        coefficient_fraction_seconds = getattr(ion_event.value, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
         fractional_precision = getattr(ion_event.value, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
         coefficient = dt.microsecond
         if coefficient is not None and fractional_precision is not None and coefficient_fraction_seconds is None:
@@ -278,9 +278,7 @@ def _serialize_timestamp(ion_event):
             if coefficient_fraction_seconds is not None:
                 exponent = -fractional_precision
                 coefficient_fraction_seconds2 = int(Decimal(coefficient_fraction_seconds * (10**fractional_precision))
-                                                   .quantize(MICROSECOND_PRECISION, rounding="ROUND_DOWN"))
-                # coefficient_fraction_seconds = coefficient_fraction_seconds * (10**fractional_precision)
-                # coefficient_fraction_seconds = int(str(coefficient_fraction_seconds)[:fractional_precision])
+                                                    .quantize(MICROSECOND_PRECISION, rounding="ROUND_DOWN"))
                 length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds2)
     _write_length(buf, length, _TypeIds.TIMESTAMP)
     buf.extend(value_buf)

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -226,19 +226,6 @@ _serialize_clob = partial(_serialize_lob_value, tid=_TypeIds.CLOB)
 
 _MICROSECOND_DECIMAL_EXPONENT = -6  # There are 1e6 microseconds per second.
 
-_TEN_EXP_MINUS_ONE = [
-    -1,
-    9,
-    99,
-    999,
-    9999,
-    99999,
-    999999,
-    9999999,
-    99999999,
-    999999999
-]
-
 
 def _serialize_timestamp(ion_event):
     buf = bytearray()
@@ -271,16 +258,17 @@ def _serialize_timestamp(ion_event):
             coefficient = dt.microsecond
         fractional_precision = getattr(ion_event.value, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
         if coefficient is not None and fractional_precision is not None:
-            if coefficient == 0 or fractional_precision > MICROSECOND_PRECISION:
+            if coefficient == 0:
                 adjusted_fractional_precision = fractional_precision
             else:
                 adjusted_fractional_precision = MICROSECOND_PRECISION
+                if fractional_precision > MICROSECOND_PRECISION:
+                    adjusted_fractional_precision = fractional_precision
                 # This optimizes the size of the fractional encoding when the extra precision is not needed.
                 while adjusted_fractional_precision > fractional_precision and coefficient % 10 == 0:
                     coefficient //= 10
                     adjusted_fractional_precision -= 1
-            if adjusted_fractional_precision > fractional_precision or \
-                    coefficient > _TEN_EXP_MINUS_ONE[fractional_precision]:
+            if adjusted_fractional_precision > fractional_precision:
                 raise ValueError('Error writing event %s. Found timestamp fractional precision of %d digits, '
                                  'which is less than needed to serialize %d microseconds.'
                                  % (ion_event, fractional_precision, dt.microsecond))

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -277,9 +277,11 @@ def _serialize_timestamp(ion_event):
         else:
             if coefficient_fraction_seconds is not None:
                 exponent = -fractional_precision
-                coefficient_fraction_seconds = int(Decimal(coefficient_fraction_seconds * (10**fractional_precision))
+                coefficient_fraction_seconds2 = int(Decimal(coefficient_fraction_seconds * (10**fractional_precision))
                                                    .quantize(MICROSECOND_PRECISION, rounding="ROUND_DOWN"))
-                length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds)
+                # coefficient_fraction_seconds = coefficient_fraction_seconds * (10**fractional_precision)
+                # coefficient_fraction_seconds = int(str(coefficient_fraction_seconds)[:fractional_precision])
+                length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds2)
     _write_length(buf, length, _TypeIds.TIMESTAMP)
     buf.extend(value_buf)
     return buf

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -277,9 +277,15 @@ def _serialize_timestamp(ion_event):
         else:
             if coefficient_fraction_seconds is not None:
                 exponent = -fractional_precision
-                coefficient_fraction_seconds2 = int(Decimal(coefficient_fraction_seconds * (10**fractional_precision))
-                                                    .quantize(MICROSECOND_PRECISION, rounding="ROUND_DOWN"))
-                length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds2)
+                coefficient_fraction_seconds_decimal = (Decimal(coefficient_fraction_seconds *
+                                                                (10**fractional_precision)))
+                coefficient_fraction_seconds_int = int(Decimal(coefficient_fraction_seconds *
+                                                               (10 ** fractional_precision)))
+                if coefficient_fraction_seconds_decimal > coefficient_fraction_seconds_int:
+                    raise ValueError('Error writing event %s. Found timestamp fractional precision of %d digits, '
+                                     'which is less than needed to serialize %d microseconds.'
+                                     % (ion_event, fractional_precision, coefficient_fraction_seconds_decimal))
+                length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds_int)
     _write_length(buf, length, _TypeIds.TIMESTAMP)
     buf.extend(value_buf)
     return buf

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -233,7 +233,7 @@ _serialize_clob = partial(_serialize_lob_value, tid=_TypeIds.CLOB)
 
 _MICROSECOND_DECIMAL_EXPONENT = -6  # There are 1e6 microseconds per second.
 
-_TEN_EXP_MINUS_ONE = [
+_TEN_EXP_MINUS_ONE = (
     -1,
     9,
     99,
@@ -241,7 +241,7 @@ _TEN_EXP_MINUS_ONE = [
     9999,
     99999,
     999999,
-]
+)
 
 
 def _serialize_timestamp(ion_event):

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -276,6 +276,9 @@ def _serialize_timestamp(ion_event):
             exponent = -adjusted_fractional_precision
             if not (coefficient == 0 and exponent >= 0):
                 length += _write_decimal_value(value_buf, exponent, coefficient)
+        else:
+            exponent = -(len(str(coefficient)))
+            length += _write_decimal_value(value_buf, exponent, coefficient)
     _write_length(buf, length, _TypeIds.TIMESTAMP)
     buf.extend(value_buf)
     return buf

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -30,7 +30,7 @@ import struct
 from amazon.ion.equivalence import _is_float_negative_zero
 from amazon.ion.symbols import SymbolToken
 from .core import IonEventType, IonType, DataEvent, Transition, TimestampPrecision, TIMESTAMP_FRACTION_PRECISION_FIELD, \
-    MICROSECOND_PRECISION, TIMESTAMP_PRECISION_FIELD, FRACTIONAL_SECONDS
+    MICROSECOND_PRECISION, TIMESTAMP_PRECISION_FIELD, TIMESTAMP_FRACTIONAL_SECONDS_FIELD
 from .util import coroutine, total_seconds, Enum
 from .writer import NOOP_WRITER_EVENT, WriteEventType, \
                     writer_trampoline, partial_transition, serialize_scalar, \
@@ -253,10 +253,11 @@ def _serialize_timestamp(ion_event):
         length += _write_varuint(value_buf, dt.minute)
     if precision.includes_second:
         length += _write_varuint(value_buf, dt.second)
-        coefficient = getattr(ion_event.value, FRACTIONAL_SECONDS, dt.microsecond)
+        coefficient = getattr(ion_event.value, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, dt.microsecond)
+        fractional_precision = None
         if coefficient is None:
             coefficient = dt.microsecond
-        fractional_precision = getattr(ion_event.value, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
+            fractional_precision = getattr(ion_event.value, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
         if coefficient is not None and fractional_precision is not None:
             if coefficient == 0:
                 adjusted_fractional_precision = fractional_precision

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -30,7 +30,7 @@ import struct
 from amazon.ion.equivalence import _is_float_negative_zero
 from amazon.ion.symbols import SymbolToken
 from .core import IonEventType, IonType, DataEvent, Transition, TimestampPrecision, TIMESTAMP_FRACTION_PRECISION_FIELD, \
-    MICROSECOND_PRECISION, TIMESTAMP_PRECISION_FIELD, FRACTIONAL_UNITS
+    MICROSECOND_PRECISION, TIMESTAMP_PRECISION_FIELD, FRACTIONAL_SECONDS
 from .util import coroutine, total_seconds, Enum
 from .writer import NOOP_WRITER_EVENT, WriteEventType, \
                     writer_trampoline, partial_transition, serialize_scalar, \
@@ -253,7 +253,7 @@ def _serialize_timestamp(ion_event):
         length += _write_varuint(value_buf, dt.minute)
     if precision.includes_second:
         length += _write_varuint(value_buf, dt.second)
-        coefficient = getattr(ion_event.value, FRACTIONAL_UNITS, dt.microsecond)
+        coefficient = getattr(ion_event.value, FRACTIONAL_SECONDS, dt.microsecond)
         if coefficient is None:
             coefficient = dt.microsecond
         fractional_precision = getattr(ion_event.value, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -170,6 +170,13 @@ def _write_decimal_value(buf, exponent, coefficient, sign=0):
     return length
 
 
+def _write_decimal_to_buf(buf, value):
+    sign, digits, exponent = value.as_tuple()
+    coefficient = int(value.scaleb(-exponent).to_integral_value())
+    length = _write_decimal_value(buf, exponent, coefficient, sign)
+    return length
+
+
 def _serialize_decimal(ion_event):
     buf = bytearray()
     value = ion_event.value
@@ -286,9 +293,7 @@ def _serialize_timestamp(ion_event):
                     length += _write_decimal_value(value_buf, exponent, coefficient)
 
         if coefficient_fraction_seconds is not None:
-            exponent = coefficient_fraction_seconds.as_tuple().exponent
-            coefficient_fraction_seconds = int(coefficient_fraction_seconds * Decimal(10 ** -exponent))
-            length += _write_decimal_value(value_buf, exponent, coefficient_fraction_seconds)
+            length += _write_decimal_to_buf(value_buf, coefficient_fraction_seconds)
     _write_length(buf, length, _TypeIds.TIMESTAMP)
     buf.extend(value_buf)
     return buf

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -184,16 +184,22 @@ def _bytes_datetime(dt):
         fractional = fractional[:fractional_precision]
         tz_string += '.' + fractional
     else:
-        if fractional_seconds is not None:
-            # fractional_seconds_decimal = ("{:." + str(fractional_precision) + "f}").format(fractional_seconds)
-            # tz_string += str(fractional_seconds_decimal)[1:]
-            if "e" in str(fractional_seconds):
-                tz_string += str(Decimal(fractional_seconds))[1:]
+        # Since 0.000... is interpreted as 0, must do this in order to have full precision 0's.
+        if fractional_seconds == 0:
+            tz_string += '.' + ('0' * fractional_precision)
+        elif fractional_seconds is not None:
+            if 'e' in str(fractional_seconds):
+                fractional_string = str(Decimal(fractional_seconds))[1:]
+                padding = fractional_precision - len(fractional_string[1:])
+                fractional_string += ('0' * padding)
+                tz_string += fractional_string
             else:
-                tz_string += str(fractional_seconds)[1:]
-    # print("hello")
-    # print(fractional_seconds)
-    # print(tz_string + _bytes_utc_offset(dt))
+                # Avoiding conversion of fractional_seconds to Decimal here. Decimal adds extra precision to values
+                # less than one, want to keep original precision as much as we can.
+                fractional_string = str(fractional_seconds)[1:]
+                padding = fractional_precision - len(fractional_string[1:])
+                fractional_string += ('0' * padding)
+                tz_string += fractional_string
     return tz_string + _bytes_utc_offset(dt)
 
 

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -173,24 +173,27 @@ def _bytes_datetime(dt):
         return tz_string + _bytes_utc_offset(dt)
 
     fractional_precision = getattr(original_dt, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
-    fractional_seconds = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD)
+    fractional_seconds = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
     if fractional_precision is not None and fractional_seconds is None:
         fractional = dt.strftime('%f')
         assert len(fractional) == MICROSECOND_PRECISION
-        fractional = str(fractional)
-        if len(fractional) < fractional_precision:
-            diff = fractional_precision - len(fractional)
-            fractional = ('0' * diff) + fractional
 
-        if fractional_precision <= MICROSECOND_PRECISION and \
-                fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
+        if fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
             raise ValueError('Found timestamp fractional with more than the specified %d digits of precision.'
                              % (fractional_precision,))
         fractional = fractional[:fractional_precision]
         tz_string += '.' + fractional
     else:
-        tz_string += str(fractional_seconds)[1:]
-
+        if fractional_seconds is not None:
+            # fractional_seconds_decimal = ("{:." + str(fractional_precision) + "f}").format(fractional_seconds)
+            # tz_string += str(fractional_seconds_decimal)[1:]
+            if "e" in str(fractional_seconds):
+                tz_string += str(Decimal(fractional_seconds))[1:]
+            else:
+                tz_string += str(fractional_seconds)[1:]
+    # print("hello")
+    # print(fractional_seconds)
+    # print(tz_string + _bytes_utc_offset(dt))
     return tz_string + _bytes_utc_offset(dt)
 
 

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -174,22 +174,16 @@ def _bytes_datetime(dt):
 
     fractional_precision = getattr(original_dt, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
     if fractional_precision:
-        if fractional_precision <= MICROSECOND_PRECISION:
-            fractional = dt.strftime('%f')
-            assert len(fractional) == MICROSECOND_PRECISION
-        else:
-            fractional = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, dt.strftime('%f'))
-            if fractional is None:
-                fractional = dt.strftime('%f')
-            fractional = str(fractional)
-            if len(fractional) < fractional_precision:
-                diff = fractional_precision - len(fractional)
-                fractional = ('0' * diff) + fractional
+        fractional = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, dt.strftime('%f'))
+        fractional = str(fractional)
+        if len(fractional) < fractional_precision:
+            diff = fractional_precision - len(fractional)
+            fractional = ('0' * diff) + fractional
 
-        if fractional_precision <= MICROSECOND_PRECISION and \
-                fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
-            raise ValueError('Found timestamp fractional with more than the specified %d digits of precision.'
-                             % (fractional_precision,))
+    if fractional_precision is not None and fractional_precision <= MICROSECOND_PRECISION and \
+            fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
+        raise ValueError('Found timestamp fractional with more than the specified %d digits of precision.'
+                         % (fractional_precision,))
         fractional = fractional[:fractional_precision]
         tz_string += '.' + fractional
 

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -35,7 +35,7 @@ from . import symbols
 
 from .util import coroutine, unicode_iter
 from .core import DataEvent, Transition, IonEventType, IonType, TIMESTAMP_PRECISION_FIELD, TimestampPrecision, \
-    _ZERO_DELTA, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION, FRACTIONAL_SECONDS
+    _ZERO_DELTA, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION, TIMESTAMP_FRACTIONAL_SECONDS_FIELD
 from .writer import partial_transition, writer_trampoline, serialize_scalar, validate_scalar_value, \
     illegal_state_null, NOOP_WRITER_EVENT
 from .writer import WriteEventType
@@ -178,7 +178,7 @@ def _bytes_datetime(dt):
             fractional = dt.strftime('%f')
             assert len(fractional) == MICROSECOND_PRECISION
         else:
-            fractional = getattr(original_dt, FRACTIONAL_SECONDS, dt.strftime('%f'))
+            fractional = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, dt.strftime('%f'))
             if fractional is None:
                 fractional = dt.strftime('%f')
             fractional = str(fractional)

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -35,7 +35,7 @@ from . import symbols
 
 from .util import coroutine, unicode_iter
 from .core import DataEvent, Transition, IonEventType, IonType, TIMESTAMP_PRECISION_FIELD, TimestampPrecision, \
-    _ZERO_DELTA, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION, FRACTIONAL_UNITS
+    _ZERO_DELTA, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION, FRACTIONAL_SECONDS
 from .writer import partial_transition, writer_trampoline, serialize_scalar, validate_scalar_value, \
     illegal_state_null, NOOP_WRITER_EVENT
 from .writer import WriteEventType
@@ -178,7 +178,7 @@ def _bytes_datetime(dt):
             fractional = dt.strftime('%f')
             assert len(fractional) == MICROSECOND_PRECISION
         else:
-            fractional = getattr(original_dt, FRACTIONAL_UNITS, dt.strftime('%f'))
+            fractional = getattr(original_dt, FRACTIONAL_SECONDS, dt.strftime('%f'))
             if fractional is None:
                 fractional = dt.strftime('%f')
             fractional = str(fractional)

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -59,7 +59,7 @@ _NULL_TYPE_NAMES = [
 ]
 
 
-def scientific_notation_to_decimal_string(value):
+def _scientific_notation_to_decimal_string(value):
     """Converts the Decimal ```value```, which must be expressed in scientific notation, to a string version of the full
     precision decimal with the zero that precedes the decimal point omitted.
 
@@ -71,8 +71,8 @@ def scientific_notation_to_decimal_string(value):
     Returns:
         string: A string version of the full precision decimal with the zero that precedes the decimal point omitted.
     """
-    value_string = str(value).replace('.', '')
-    pos = value_string.find('E')
+    value_string = str(value).replace('.', '').lower()
+    pos = value_string.find('e')
     number_value = value_string[:pos]
     exponent_value = value_string[pos + 1:]
     total_num_of_zeroes = (int(exponent_value) * -1) - 1
@@ -209,8 +209,8 @@ def _bytes_datetime(dt):
     if fractional_seconds == 0:
         tz_string += '.' + ('0' * fractional_precision)
     elif fractional_seconds is not None:
-        if 'E' in str(fractional_seconds):
-            tz_string += scientific_notation_to_decimal_string(fractional_seconds)
+        if 'e' in str(fractional_seconds).lower():
+            tz_string += _scientific_notation_to_decimal_string(fractional_seconds)
         else:
             tz_string += str(fractional_seconds)[1:]
     return tz_string + _bytes_utc_offset(dt)

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -182,6 +182,9 @@ def _bytes_datetime(dt):
             if fractional is None:
                 fractional = dt.strftime('%f')
             fractional = str(fractional)
+            if len(fractional) < fractional_precision:
+                diff = fractional_precision - len(fractional)
+                fractional = ('0' * diff) + fractional
 
         if fractional_precision <= MICROSECOND_PRECISION and \
                 fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -178,11 +178,15 @@ def _bytes_datetime(dt):
         fractional = dt.strftime('%f')
         assert len(fractional) == MICROSECOND_PRECISION
 
-        if fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
-            raise ValueError('Found timestamp fractional with more than the specified %d digits of precision.'
-                             % (fractional_precision,))
-        fractional = fractional[:fractional_precision]
-        tz_string += '.' + fractional
+        if fractional_precision is not None:
+            if fractional[fractional_precision:] != ('0' * (MICROSECOND_PRECISION - fractional_precision)):
+                raise ValueError('Found timestamp fractional with more than the specified %d digits of precision.'
+                                 % (fractional_precision,))
+            fractional = fractional[:fractional_precision]
+            tz_string += '.' + fractional
+
+    if fractional_seconds == 0:
+        tz_string += '.' + ('0' * fractional_precision)
     elif fractional_seconds is not None:
         tz_string += str(fractional_seconds)[1:]
     return tz_string + _bytes_utc_offset(dt)

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -59,6 +59,27 @@ _NULL_TYPE_NAMES = [
 ]
 
 
+def scientific_notation_to_decimal_string(value):
+    """Converts the Decimal ```value```, which must be expressed in scientific notation, to a string version of the full
+    precision decimal with the zero that precedes the decimal point omitted.
+
+    Input example: Decimal('1.2E-14')
+    Output example: '.000000000000012'
+
+    Args:
+        value (Decimal): The numerical value, which must be expressed in scientific notation
+    Returns:
+        string: A string version of the full precision decimal with the zero that precedes the decimal point omitted.
+    """
+    value_string = str(value).replace('.', '')
+    pos = value_string.find('E')
+    number_value = value_string[:pos]
+    exponent_value = value_string[pos + 1:]
+    total_num_of_zeroes = (int(exponent_value) * -1) - 1
+    decimal_string = '.' + ('0' * total_num_of_zeroes) + number_value
+    return decimal_string
+
+
 def _serialize_bool(ion_event):
     if ion_event.value:
         return b'true'
@@ -188,7 +209,10 @@ def _bytes_datetime(dt):
     if fractional_seconds == 0:
         tz_string += '.' + ('0' * fractional_precision)
     elif fractional_seconds is not None:
-        tz_string += str(fractional_seconds)[1:]
+        if 'E' in str(fractional_seconds):
+            tz_string += scientific_notation_to_decimal_string(fractional_seconds)
+        else:
+            tz_string += str(fractional_seconds)[1:]
     return tz_string + _bytes_utc_offset(dt)
 
 

--- a/amazon/ion/writer_text.py
+++ b/amazon/ion/writer_text.py
@@ -174,7 +174,7 @@ def _bytes_datetime(dt):
 
     fractional_precision = getattr(original_dt, TIMESTAMP_FRACTION_PRECISION_FIELD, MICROSECOND_PRECISION)
     fractional_seconds = getattr(original_dt, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
-    if fractional_precision is not None and fractional_seconds is None:
+    if fractional_seconds is None:
         fractional = dt.strftime('%f')
         assert len(fractional) == MICROSECOND_PRECISION
 
@@ -183,23 +183,8 @@ def _bytes_datetime(dt):
                              % (fractional_precision,))
         fractional = fractional[:fractional_precision]
         tz_string += '.' + fractional
-    else:
-        # Since 0.000... is interpreted as 0, must do this in order to have full precision 0's.
-        if fractional_seconds == 0:
-            tz_string += '.' + ('0' * fractional_precision)
-        elif fractional_seconds is not None:
-            if 'e' in str(fractional_seconds):
-                fractional_string = str(Decimal(fractional_seconds))[1:]
-                padding = fractional_precision - len(fractional_string[1:])
-                fractional_string += ('0' * padding)
-                tz_string += fractional_string
-            else:
-                # Avoiding conversion of fractional_seconds to Decimal here. Decimal adds extra precision to values
-                # less than one, want to keep original precision as much as we can.
-                fractional_string = str(fractional_seconds)[1:]
-                padding = fractional_precision - len(fractional_string[1:])
-                fractional_string += ('0' * padding)
-                tz_string += fractional_string
+    elif fractional_seconds is not None:
+        tz_string += str(fractional_seconds)[1:]
     return tz_string + _bytes_utc_offset(dt)
 
 

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -86,6 +86,10 @@ _EQUIVS = (
         _timestamp(_dt(1, 1, 1, 0, 0, 0, 0, tzinfo=None)),
         _ts(1, microsecond=0, precision=_TP.SECOND, fractional_precision=6),
         _timestamp(_ts(1, microsecond=0, precision=_TP.SECOND)),
+        _ts(1, microsecond=0, precision=_TP.SECOND, fractional_seconds=0),
+        _timestamp(_ts(1, microsecond=0, precision=_TP.SECOND, fractional_seconds=0)),
+        _ts(1, precision=_TP.SECOND, fractional_seconds=0),
+        _timestamp(_ts(1, precision=_TP.SECOND, fractional_seconds=0))
     ),
     (
         u'abc',
@@ -147,6 +151,9 @@ _EQUIVS_INSTANTS = (
         _dt(2000, 1, 1, 1, tzinfo=OffsetTZInfo(timedelta(hours=1))),
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
         _timestamp(_ts(2000, 1, 1, 1, off_hours=1, off_minutes=0, precision=_TP.SECOND)),
+        _ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0),
+        _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0)),
+        _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=None))
     ),
 )
 
@@ -191,6 +198,13 @@ _NONEQUIVS = (
         _dt(2000, 1, 1, tzinfo=OffsetTZInfo()),
         _timestamp(_ts(2000, 1, 1, 1, off_hours=1, off_minutes=0, precision=_TP.SECOND)),
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
+        None,
+    ),
+    (
+        # Timestamps with different fractional seconds are not equivalent.
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.123456789'))),
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.123456'))),
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=None)),
         None,
     ),
     (

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -86,10 +86,7 @@ _EQUIVS = (
         _timestamp(_dt(1, 1, 1, 0, 0, 0, 0, tzinfo=None)),
         _ts(1, microsecond=0, precision=_TP.SECOND, fractional_precision=6),
         _timestamp(_ts(1, microsecond=0, precision=_TP.SECOND)),
-        # _ts(1, microsecond=None, precision=_TP.SECOND, fractional_seconds=0),
-        # _timestamp(_ts(1, microsecond=None, precision=_TP.SECOND, fractional_seconds=0)),
-        # _ts(1, precision=_TP.SECOND, fractional_seconds=0),
-        # _timestamp(_ts(1, precision=_TP.SECOND, fractional_seconds=0))
+        _ts(1, precision=_TP.SECOND, fractional_seconds=Decimal('0.000000')),
     ),
     (
         u'abc',
@@ -151,9 +148,8 @@ _EQUIVS_INSTANTS = (
         _dt(2000, 1, 1, 1, tzinfo=OffsetTZInfo(timedelta(hours=1))),
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
         _timestamp(_ts(2000, 1, 1, 1, off_hours=1, off_minutes=0, precision=_TP.SECOND)),
-        # _ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0),
-        # _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0)),
-        # _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=None))
+        _timestamp(_ts(2000, 1, 1, 1, off_hours=1, off_minutes=0, precision=_TP.SECOND,
+                       fractional_seconds=Decimal('0.000000'))),
     ),
 )
 
@@ -200,16 +196,13 @@ _NONEQUIVS = (
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
         None,
     ),
-    # (
-    #     # Timestamps with different fractional seconds are not equivalent.
-    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
-    #                    fractional_seconds=Decimal('0.123456789'))),
-    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
-    #                    fractional_seconds=Decimal('0.999999999'))),
-    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
-    #                    fractional_seconds=Decimal('0.000000000'))),
-    #     None,
-    # ),
+    (
+        # Timestamps with different fractional seconds are not equivalent.
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.123456789'))),
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.9999999'))),
+        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.000000000'))),
+        None,
+    ),
     (
         _string(u'abc'),
         u'abcd',

--- a/tests/test_equivalence.py
+++ b/tests/test_equivalence.py
@@ -86,10 +86,10 @@ _EQUIVS = (
         _timestamp(_dt(1, 1, 1, 0, 0, 0, 0, tzinfo=None)),
         _ts(1, microsecond=0, precision=_TP.SECOND, fractional_precision=6),
         _timestamp(_ts(1, microsecond=0, precision=_TP.SECOND)),
-        _ts(1, microsecond=0, precision=_TP.SECOND, fractional_seconds=0),
-        _timestamp(_ts(1, microsecond=0, precision=_TP.SECOND, fractional_seconds=0)),
-        _ts(1, precision=_TP.SECOND, fractional_seconds=0),
-        _timestamp(_ts(1, precision=_TP.SECOND, fractional_seconds=0))
+        # _ts(1, microsecond=None, precision=_TP.SECOND, fractional_seconds=0),
+        # _timestamp(_ts(1, microsecond=None, precision=_TP.SECOND, fractional_seconds=0)),
+        # _ts(1, precision=_TP.SECOND, fractional_seconds=0),
+        # _timestamp(_ts(1, precision=_TP.SECOND, fractional_seconds=0))
     ),
     (
         u'abc',
@@ -151,9 +151,9 @@ _EQUIVS_INSTANTS = (
         _dt(2000, 1, 1, 1, tzinfo=OffsetTZInfo(timedelta(hours=1))),
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
         _timestamp(_ts(2000, 1, 1, 1, off_hours=1, off_minutes=0, precision=_TP.SECOND)),
-        _ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0),
-        _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0)),
-        _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=None))
+        # _ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0),
+        # _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=0)),
+        # _timestamp(_ts(2000, 1, 1, 0, precision=_TP.SECOND, fractional_seconds=None))
     ),
 )
 
@@ -200,13 +200,16 @@ _NONEQUIVS = (
         _ts(1999, 12, 31, 23, 59, off_hours=0, off_minutes=-1, precision=_TP.SECOND),
         None,
     ),
-    (
-        # Timestamps with different fractional seconds are not equivalent.
-        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.123456789'))),
-        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=Decimal('0.123456'))),
-        _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_seconds=None)),
-        None,
-    ),
+    # (
+    #     # Timestamps with different fractional seconds are not equivalent.
+    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
+    #                    fractional_seconds=Decimal('0.123456789'))),
+    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
+    #                    fractional_seconds=Decimal('0.999999999'))),
+    #     _timestamp(_ts(2000, 1, 1, 1, precision=_TP.SECOND, fractional_precision=9,
+    #                    fractional_seconds=Decimal('0.000000000'))),
+    #     None,
+    # ),
     (
         _string(u'abc'),
         u'abcd',

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -186,6 +186,11 @@ _TOP_LEVEL_VALUES = (
         e_timestamp(_ts(2016, 2, 2, 0, 0, 30, off_hours=-7, precision=_PREC_SECOND))
     ),
     (
+        b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC7\x01',
+        e_timestamp(_ts(1, 1, 1, 0, 0, 0, None, precision=_PREC_SECOND, fractional_precision=7,
+                        fractional_seconds=Decimal('1e-7')))
+    ),
+    (
         b'\x6B\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E\xC3\x01',
         e_timestamp(_ts(
             2016, 2, 2, 0, 0, 30, 1000, off_hours=-7, precision=_PREC_SECOND, fractional_precision=3
@@ -243,10 +248,10 @@ _TOP_LEVEL_VALUES = (
 
     (b'\xBF', e_null_list()),
     (b'\xB0', e_start_list(), e_end_list()),
-    
+
     (b'\xCF', e_null_sexp()),
     (b'\xC0', e_start_sexp(), e_end_sexp()),
-    
+
     (b'\xDF', e_null_struct()),
     (b'\xD0', e_start_struct(), e_end_struct()),
     (b'\xD1\x82\x84\x20', e_start_struct(), e_int(0, field_name=SymbolToken(None, 4)), e_end_struct())

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -96,8 +96,6 @@ _BASIC_PARAMS = (
 )
 
 _BAD_VALUES = (
-    # Only up to microsecond precision is supported (6 digits).
-    (b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC7\x01', 'OVERFLOWING TIMESTAMP PRECISION'),
     # The annotation wrapper declares 6 octets, but the wrapped value (a symbol value) ends after only 4.
     (b'\xe6\x81\x84\x71\x04\x71\x04', 'ANNOT LENGTH TOO LONG - SCALAR'),
     # The annotation wrapper declares 6 octets, but the wrapped value (a list) ends after only 4.

--- a/tests/test_reader_binary.py
+++ b/tests/test_reader_binary.py
@@ -187,7 +187,7 @@ _TOP_LEVEL_VALUES = (
     ),
     (
         b'\x69\xC0\x81\x81\x81\x80\x80\x80\xC7\x01',
-        e_timestamp(_ts(1, 1, 1, 0, 0, 0, None, precision=_PREC_SECOND, fractional_precision=7,
+        e_timestamp(_ts(1, 1, 1, 0, 0, 0, None, precision=_PREC_SECOND, fractional_precision=None,
                         fractional_seconds=Decimal('1e-7')))
     ),
     (

--- a/tests/test_reader_text.py
+++ b/tests/test_reader_text.py
@@ -788,27 +788,6 @@ _GOOD_SCALARS = (
             2000, 1, 1, 0, 0, 0, 999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=6
         ))
     ),
-    # (
-    #     b'2000-01-01T00:00:00.9999999Z',
-    #     e_timestamp(_ts(
-    #         2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
-    #         fractional_seconds=Decimal('0.9999999')
-    #     ))
-    # ),
-    # (
-    #     b'2000-01-01T00:00:00.1234567Z',
-    #     e_timestamp(_ts(
-    #         2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
-    #         fractional_seconds=Decimal('0.1234567')
-    #     ))
-    # ),
-    # (
-    #     b'2000-01-01T00:00:00.1234567800Z',
-    #     e_timestamp(_ts(
-    #         2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10,
-    #         fractional_seconds=Decimal('0.1234567800')
-    #     ))
-    # ),
     (
         b'2000-01-01T00:00:00.000-00:00',
         e_timestamp(_ts(2000, 1, 1, 0, 0, 0, 0, precision=_tp.SECOND, fractional_precision=3))

--- a/tests/test_reader_text.py
+++ b/tests/test_reader_text.py
@@ -789,6 +789,27 @@ _GOOD_SCALARS = (
         ))
     ),
     (
+        b'2000-01-01T00:00:00.9999999Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, None, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=None,
+            fractional_seconds=Decimal('0.9999999')
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.1234567Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, None, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=None,
+            fractional_seconds=Decimal('0.1234567')
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.1234567800Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, None, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=None,
+            fractional_seconds=Decimal('0.1234567800')
+        ))
+    ),
+    (
         b'2000-01-01T00:00:00.000-00:00',
         e_timestamp(_ts(2000, 1, 1, 0, 0, 0, 0, precision=_tp.SECOND, fractional_precision=3))
     ),

--- a/tests/test_reader_text.py
+++ b/tests/test_reader_text.py
@@ -205,7 +205,6 @@ _BAD_VALUE = (
     (b'2000-01-01T24:00Z',),  # Hour is 0..23.
     (b'2000-01-01T00:60Z',),  # Minute is 0..59.
     (b'2000-01-01T00:00:60Z',),  # Second is 0..59.
-    (b'2000-01-01T00:00:00.9999999Z',),  # Only up to microsecond-level precision is supported.
     (b'2000-01-01T00:00:00.000+24:00',),  # Hour offset is 0..23.
     (b'2000-01-01T00:00:00.000+00:60',),  # Minute offset is 0..59.
     (b'"\\udbff\\u3000"',),  # Malformed surrogate pair (\u3000 is not a low surrogate).
@@ -787,6 +786,30 @@ _GOOD_SCALARS = (
         b'2000-01-01T00:00:00.99999900000Z',
         e_timestamp(_ts(
             2000, 1, 1, 0, 0, 0, 999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=6
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.9999999Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.1234567Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.1234567800Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10
+        ))
+    ),
+    (
+        b'2000-01-01T00:00:00.1234567Z',
+        e_timestamp(_ts(
+            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
         ))
     ),
     (

--- a/tests/test_reader_text.py
+++ b/tests/test_reader_text.py
@@ -788,27 +788,27 @@ _GOOD_SCALARS = (
             2000, 1, 1, 0, 0, 0, 999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=6
         ))
     ),
-    (
-        b'2000-01-01T00:00:00.9999999Z',
-        e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
-            fractional_seconds=Decimal('0.9999999')
-        ))
-    ),
-    (
-        b'2000-01-01T00:00:00.1234567Z',
-        e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
-            fractional_seconds=Decimal('0.1234567')
-        ))
-    ),
-    (
-        b'2000-01-01T00:00:00.1234567800Z',
-        e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10,
-            fractional_seconds=Decimal('0.1234567800')
-        ))
-    ),
+    # (
+    #     b'2000-01-01T00:00:00.9999999Z',
+    #     e_timestamp(_ts(
+    #         2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
+    #         fractional_seconds=Decimal('0.9999999')
+    #     ))
+    # ),
+    # (
+    #     b'2000-01-01T00:00:00.1234567Z',
+    #     e_timestamp(_ts(
+    #         2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
+    #         fractional_seconds=Decimal('0.1234567')
+    #     ))
+    # ),
+    # (
+    #     b'2000-01-01T00:00:00.1234567800Z',
+    #     e_timestamp(_ts(
+    #         2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10,
+    #         fractional_seconds=Decimal('0.1234567800')
+    #     ))
+    # ),
     (
         b'2000-01-01T00:00:00.000-00:00',
         e_timestamp(_ts(2000, 1, 1, 0, 0, 0, 0, precision=_tp.SECOND, fractional_precision=3))

--- a/tests/test_reader_text.py
+++ b/tests/test_reader_text.py
@@ -791,25 +791,22 @@ _GOOD_SCALARS = (
     (
         b'2000-01-01T00:00:00.9999999Z',
         e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
+            2000, 1, 1, 0, 0, 0, 9999999, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
+            fractional_seconds=Decimal('0.9999999')
         ))
     ),
     (
         b'2000-01-01T00:00:00.1234567Z',
         e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
+            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7,
+            fractional_seconds=Decimal('0.1234567')
         ))
     ),
     (
         b'2000-01-01T00:00:00.1234567800Z',
         e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10
-        ))
-    ),
-    (
-        b'2000-01-01T00:00:00.1234567Z',
-        e_timestamp(_ts(
-            2000, 1, 1, 0, 0, 0, 1234567, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=7
+            2000, 1, 1, 0, 0, 0, 1234567800, off_hours=0, off_minutes=0, precision=_tp.SECOND, fractional_precision=10,
+            fractional_seconds=Decimal('0.1234567800')
         ))
     ),
     (

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -49,7 +49,7 @@ _EVENT_TYPES = [
     (IonPyInt, e_int(2 ** 64 + 1)),
     (IonPyFloat, e_float(1e0)),
     (IonPyDecimal, e_decimal(Decimal('1.1'))),
-    (IonPyTimestamp, e_timestamp(datetime(2012, 1, 1))),
+    (IonPyTimestamp, e_timestamp(Timestamp(2012, 1, 1))),
     (IonPyTimestamp, e_timestamp(Timestamp(2012, 1, 1, precision=TimestampPrecision.DAY))),
     (IonPySymbol, e_symbol(SymbolToken(u'Hola', None, None))),
     (IonPyText, e_string(u'Hello')),

--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -49,7 +49,7 @@ _EVENT_TYPES = [
     (IonPyInt, e_int(2 ** 64 + 1)),
     (IonPyFloat, e_float(1e0)),
     (IonPyDecimal, e_decimal(Decimal('1.1'))),
-    (IonPyTimestamp, e_timestamp(Timestamp(2012, 1, 1))),
+    (IonPyTimestamp, e_timestamp(datetime(2012, 1, 1))),
     (IonPyTimestamp, e_timestamp(Timestamp(2012, 1, 1, precision=TimestampPrecision.DAY))),
     (IonPySymbol, e_symbol(SymbolToken(u'Hola', None, None))),
     (IonPyText, e_string(u'Hello')),

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -30,27 +30,27 @@ MISSING_MICROSECOND = [
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
+        precision=TimestampPrecision.SECOND, fractional_seconds=0
         ), 0),
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456')
+        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456')
         ), 123456),
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=9, fractional_seconds=Decimal('0.123456789')
+        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456789')
         ), 123456),
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.000123')
+        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.000123')
         ), 123),
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123000')
+        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123000')
         ), 123000)
 ]
 
@@ -79,25 +79,6 @@ MISSING_FRACTIONAL_PRECISION = [
 ]
 
 
-LARGE_MICROSECOND_FIELD = [
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 12345678,
-        precision=TimestampPrecision.SECOND, fractional_precision=8, fractional_seconds=Decimal('0.12345678')
-        ), 123456),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 9999999,
-        precision=TimestampPrecision.SECOND, fractional_precision=7, fractional_seconds=Decimal('0.9999999')
-        ), 999999),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 1337894870,
-        precision=TimestampPrecision.SECOND, fractional_precision=10, fractional_seconds=Decimal('0.1337894870')
-        ), 133789),
-]
-
-
 @listify
 def event_type_parameters(list_name):
     print(list_name)
@@ -122,28 +103,12 @@ def test_missing_fractional_seconds(item):
     assert timestamp.fractional_seconds == expected_fractional_second
 
 
-@parametrize(*event_type_parameters(LARGE_MICROSECOND_FIELD))
-def test_large_microsecond_field_value(item):
-    timestamp = item.timestamps
-    expected_microsecond = item.expected_value
-    assert timestamp.microsecond == expected_microsecond
-
-
 def test_nonequivalent_microsecond_and_fractional_seconds():
     with pytest.raises(ValueError):
         Timestamp(
             2011, 1, 1,
             0, 0, 0, 123456,
             precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
-        )
-
-
-def test_fractional_seconds_with_no_fractional_precision():
-    with pytest.raises(ValueError):
-        Timestamp(
-            2011, 1, 1,
-            0, 0, 0, None,
-            precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('0.123')
         )
 
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -1,0 +1,138 @@
+# Copyright 2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+# Python 2/3 compatibility
+from decimal import Decimal
+
+import pytest
+
+from amazon.ion.core import Timestamp, TimestampPrecision, record
+from tests import parametrize
+
+
+class _P(record('timestamps', 'expected_microseconds')):
+    def __str__(self):
+        return self.desc
+
+
+MISSING_MICROSECOND = _P(
+    timestamps=[Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456')
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456789')
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.000123')
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123000')
+            )],
+    expected_microseconds=[0, 123456, 123456, 123, 123000]
+)
+
+
+@parametrize(
+    MISSING_MICROSECOND
+)
+def test_missing_microsecond(item):
+    for i in range(len(item.timestamps)):
+        assert item.timestamps[i].microsecond == item.expected_microseconds[i]
+
+
+class _P(record('timestamps', 'expected_fractional_precision')):
+    def __str__(self):
+        return self.desc
+
+
+MISSING_FRACTIONAL_PRECISION = _P(
+    timestamps=[Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 0,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123456,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+            ),
+            Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123000,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+            )],
+    expected_fractional_precision=[0, Decimal('0.123456'), Decimal('0.000123'), Decimal('0.123000')]
+)
+
+
+@parametrize(
+    MISSING_FRACTIONAL_PRECISION
+)
+def test_missing_fractional_seconds(item):
+    for i in range(len(item.timestamps)):
+        assert item.timestamps[i].fractional_seconds == item.expected_fractional_precision[i]
+
+
+def test_nonequivalent_microsecond_and_fractional_seconds():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123456,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
+        )
+
+
+def test_fractional_seconds_with_no_fractional_precision():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('0.123')
+        )
+
+
+def test_fractional_precision_less_than_1():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 0,
+            precision=TimestampPrecision.SECOND, fractional_precision=0, fractional_seconds=0
+        )
+
+
+def test_fractional_seconds_greater_than_1():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 0,
+            precision=TimestampPrecision.SECOND, fractional_precision=1, fractional_seconds=2
+        )

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -27,55 +27,82 @@ class _P(record('timestamps', 'expected_value')):
 
 
 MISSING_MICROSECOND = [
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_seconds=0
-        ), 0),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456')
-        ), 123456),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456789')
-        ), 123456),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.000123')
-        ), 123),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123000')
-        ), 123000)
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0')
+        ),
+        0
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456')
+        ),
+        123456
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123456789')
+        ),
+        123456
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.000123')
+        ),
+        123
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_seconds=Decimal('0.123000')
+        ),
+        123000
+    )
 ]
 
 
-MISSING_FRACTIONAL_PRECISION = [
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 0,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
-        ), 0),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 123456,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
-        ), Decimal('0.123456')),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 123,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
-        ), Decimal('0.000123')),
-    (Timestamp(
-        2011, 1, 1,
-        0, 0, 0, 123000,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
-        ), Decimal('0.123000'))
+MISSING_FRACTIONAL_SECONDS = [
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 0,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+        ),
+        Decimal('0')
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123456,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+        ),
+        Decimal('0.123456')
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+        ),
+        Decimal('0.000123')
+    ),
+    (
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123000,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=None
+        ),
+        Decimal('0.123000')
+    )
 ]
 
 
@@ -96,11 +123,20 @@ def test_missing_microsecond(item):
     assert timestamp.microsecond == expected_microsecond
 
 
-@parametrize(*event_type_parameters(MISSING_FRACTIONAL_PRECISION))
+@parametrize(*event_type_parameters(MISSING_FRACTIONAL_SECONDS))
 def test_missing_fractional_seconds(item):
     timestamp = item.timestamps
     expected_fractional_second = item.expected_value
     assert timestamp.fractional_seconds == expected_fractional_second
+
+
+def test_fractional_seconds_when_microseconds_and_fractional_precision_are_0():
+    timestamp = Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 0,
+            precision=TimestampPrecision.SECOND, fractional_precision=0, fractional_seconds=None
+            )
+    assert timestamp.fractional_seconds == Decimal('0')
 
 
 def test_fractional_precision_with_no_microseconds():
@@ -116,8 +152,26 @@ def test_fractional_precision_less_than_1():
     with pytest.raises(ValueError):
         Timestamp(
             2011, 1, 1,
-            0, 0, 0, 0,
-            precision=TimestampPrecision.SECOND, fractional_precision=0, fractional_seconds=0
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=-1, fractional_seconds=None
+        )
+
+
+def test_fractional_precision_greater_than_6():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=7, fractional_seconds=None
+        )
+
+
+def test_fractional_seconds_less_than_0():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('-1')
         )
 
 
@@ -125,8 +179,8 @@ def test_fractional_seconds_greater_than_1():
     with pytest.raises(ValueError):
         Timestamp(
             2011, 1, 1,
-            0, 0, 0, 0,
-            precision=TimestampPrecision.SECOND, fractional_precision=1, fractional_seconds=2
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('2')
         )
 
 
@@ -146,4 +200,14 @@ def test_fractional_seconds_with_fractional_precision():
             0, 0, 0, None,
             precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456')
         )
+
+
+def test_microseconds_not_0_when_fractional_precision_is_0():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 123456,
+            precision=TimestampPrecision.SECOND, fractional_precision=0, fractional_seconds=None
+        )
+
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -40,7 +40,7 @@ MISSING_MICROSECOND = [
     (Timestamp(
         2011, 1, 1,
         0, 0, 0, None,
-        precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456789')
+        precision=TimestampPrecision.SECOND, fractional_precision=9, fractional_seconds=Decimal('0.123456789')
         ), 123456),
     (Timestamp(
         2011, 1, 1,
@@ -129,36 +129,56 @@ def test_large_microsecond_field_value(item):
     assert timestamp.microsecond == expected_microsecond
 
 
-def test_invalid_timestamp_constructor_parameters():
+def test_nonequivalent_microsecond_and_fractional_seconds():
     with pytest.raises(ValueError):
-        # Non-equivalent microseconds and fractional seconds.
         Timestamp(
             2011, 1, 1,
             0, 0, 0, 123456,
             precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
         )
 
+
+def test_fractional_seconds_with_no_fractional_precision():
     with pytest.raises(ValueError):
-        # Fractional seconds with no fractional precision.
         Timestamp(
             2011, 1, 1,
             0, 0, 0, None,
             precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('0.123')
         )
 
+
+def test_fractional_precision_less_than_1():
     with pytest.raises(ValueError):
-        # Fractional precision is less than 1.
         Timestamp(
             2011, 1, 1,
             0, 0, 0, 0,
             precision=TimestampPrecision.SECOND, fractional_precision=0, fractional_seconds=0
         )
 
+
+def test_fractional_seconds_greater_than_1():
     with pytest.raises(ValueError):
-        # Fractional seconds is greater than 1.
         Timestamp(
             2011, 1, 1,
             0, 0, 0, 0,
             precision=TimestampPrecision.SECOND, fractional_precision=1, fractional_seconds=2
+        )
+
+
+def test_fractional_seconds_with_microseconds():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, 1,
+            precision=TimestampPrecision.SECOND, fractional_precision=None, fractional_seconds=Decimal('0.123456')
+        )
+
+
+def test_fractional_seconds_with_fractional_precision():
+    with pytest.raises(ValueError):
+        Timestamp(
+            2011, 1, 1,
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=Decimal('0.123456')
         )
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -103,12 +103,12 @@ def test_missing_fractional_seconds(item):
     assert timestamp.fractional_seconds == expected_fractional_second
 
 
-def test_nonequivalent_microsecond_and_fractional_seconds():
+def test_fractional_precision_with_no_microseconds():
     with pytest.raises(ValueError):
         Timestamp(
             2011, 1, 1,
-            0, 0, 0, 123456,
-            precision=TimestampPrecision.SECOND, fractional_precision=6, fractional_seconds=0
+            0, 0, 0, None,
+            precision=TimestampPrecision.SECOND, fractional_precision=6
         )
 
 

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -96,7 +96,6 @@ _SKIP_LIST = (
     # TEXT:
     _good_file(u'subfieldVarUInt.ion'),  # TODO amzn/ion-python#34
     _good_file(u'subfieldVarUInt32bit.ion'),  # TODO amzn/ion-python#34
-    _equivs_file(u'timestampsLargeFractionalPrecision.ion'),  # TODO amzn/ion-python#35
     _nonequivs_file(u'symbolTablesUnknownText.ion'),  # TODO amzn/ion-python#46
     # BINARY:
     _good_file(u'item1.10n'),  # TODO amzn/ion-python#46


### PR DESCRIPTION
Issue #35 

- Store the fractional seconds component as a property on the Timestamp object, storing full fidelity.
- Truncate the fractional seconds to microseconds, if need be, and pass that to the Timestamp/datetime.
- When serializing said Timestamp object the writer will use that fractional seconds field to encode the timestamp in text/binary with whatever fidelity it was set. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.