### PR TITLE
Adds the 'tuple_as_sexp' option to simpleion dump/dumps, giving the users the option to write tuples as Ion s-expressions.

### DIFF
--- a/tests/test_simple_types.py
+++ b/tests/test_simple_types.py
@@ -30,7 +30,7 @@ from amazon.ion.simple_types import is_null, IonPyNull, IonPyBool, IonPyInt, Ion
                                     IonPyDecimal, IonPyTimestamp, IonPyText, IonPyBytes, \
                                     IonPyList, IonPyDict, IonPySymbol
 from amazon.ion.equivalence import ion_equals
-from amazon.ion.simpleion import _ion_type
+from amazon.ion.simpleion import _ion_type, _FROM_TYPE
 
 _TEST_FIELD_NAME = SymbolToken('foo', 10)
 _TEST_ANNOTATIONS = (SymbolToken('bar', 11),)
@@ -107,8 +107,9 @@ def test_event_types(p):
     assert value_output.ion_type is ion_type
     assert p.event.annotations == value_output.ion_annotations
 
+
 def test_subclass_types():
     class Foo(dict):
         pass
 
-    assert _ion_type(Foo()) is IonType.STRUCT
+    assert _ion_type(Foo(), _FROM_TYPE) is IonType.STRUCT


### PR DESCRIPTION
*Issue #, if available:*
#96 

*Description of changes:*
Before this change, the only way to write an s-expression using simpleion was first to construct an `IonPyList`, e.g.`IonPyList.from_value(IonType.SEXP, ('foo', 'bar'))`.

After this change, the user can simply enable the `tuple_as_sexp` option on `simpleion.dump` or `simpleion.dumps` to have tuples written directly to s-expressions without requiring an `IonPyList`. For example:

```
>>> dumps((123, u'abc', ({u'foo': ()}, )), binary=False, tuple_as_sexp=True)
'$ion_1_0 (123 "abc" ({foo:()}))'
>>> dumps((123, u'abc', ({u'foo': ()}, )), binary=False, tuple_as_sexp=False)
'$ion_1_0 [123,"abc",[{foo:[]}]]'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
