### PR TITLE
Simplifies text writing of timestamps with Decimal fractional seconds.

### DIFF
--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -26,7 +26,7 @@ import six
 import sys
 
 from amazon.ion.core import Transition, ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, IonType, IonEvent, \
-    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, _scale_to_precision
+    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT
 from amazon.ion.exceptions import IonException
 from amazon.ion.reader import BufferQueue, reader_trampoline, ReadEventType, safe_unichr, CodePointArray, CodePoint, \
     _NARROW_BUILD
@@ -926,9 +926,7 @@ def _parse_timestamp(tokens):
 
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
-                fraction_digits = len(fraction)
-                fraction = int(fraction)
-                fraction = _scale_to_precision(fraction, fraction_digits)
+                fraction = Decimal(int(fraction)).scaleb(-1 * len(fraction))
         return timestamp(
             year, month, day,
             hour, minute, second, None,

--- a/tests/writer_util.py
+++ b/tests/writer_util.py
@@ -159,6 +159,16 @@ SIMPLE_SCALARS_MAP_TEXT = {
         (_DT(2016, 1, 1, 12, 34, 12, tzinfo=OffsetTZInfo()), b'2016-01-01T12:34:12.000000Z'),
         (_DT(2016, 1, 1, 12, 34, 12, tzinfo=OffsetTZInfo(timedelta(hours=-7))),
             b'2016-01-01T12:34:12.000000-07:00'),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
+                      fractional_seconds=Decimal('0.000010000')),
+            b'2016-02-02T00:00:30.000010000-00:00'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
+                      fractional_seconds=Decimal('0.7e-500')),
+            b'2016-02-02T00:00:30.' + b'0' * 500 + b'7-00:00'
+        )
     ),
     _IT.SYMBOL: (
         (None, b'null.symbol'),
@@ -288,6 +298,16 @@ SIMPLE_SCALARS_MAP_BINARY = {
                       precision=TimestampPrecision.SECOND, fractional_precision=1),
             b'\x6B\x43\xA4\x0F\xE0\x82\x82\x87\x80\x9E\xC1\x01'
         ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
+                      fractional_seconds=Decimal('0.000010000')),
+            b'\x6B\xC0\x0F\xE0\x82\x82\x80\x80\x9E\xC9\x27\x10'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
+                      fractional_seconds=Decimal('0.7e-500')),
+            b'\x6B\xC0\x0F\xE0\x82\x82\x80\x80\x9E\x43\xF5\x07'
+        )
     ),
     _IT.SYMBOL: (
         (None, b'\x7F'),


### PR DESCRIPTION
*Issue #, if available:*
Continues #100 

*Description of changes:*
Creates a unified path for text serialization of timestamp fractional seconds regardless of how `str` would represent the Decimal. Reduces string manipulations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
