### PR TITLE
Simplifies caluculation of fractional seconds from an integer.

### DIFF
--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -26,7 +26,7 @@ import six
 import sys
 
 from amazon.ion.core import Transition, ION_STREAM_INCOMPLETE_EVENT, ION_STREAM_END_EVENT, IonType, IonEvent, \
-    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT, _scale_to_precision
+    IonEventType, IonThunkEvent, TimestampPrecision, timestamp, ION_VERSION_MARKER_EVENT
 from amazon.ion.exceptions import IonException
 from amazon.ion.reader import BufferQueue, reader_trampoline, ReadEventType, safe_unichr, CodePointArray, CodePoint, \
     _NARROW_BUILD
@@ -926,9 +926,7 @@ def _parse_timestamp(tokens):
 
             fraction = tokens[_TimestampState.FRACTIONAL]
             if fraction is not None:
-                fraction_digits = len(fraction)
-                fraction = int(fraction)
-                fraction = _scale_to_precision(fraction, fraction_digits)
+                fraction = Decimal(int(fraction)).scaleb(-1 * len(fraction))
         return timestamp(
             year, month, day,
             hour, minute, second, None,


### PR DESCRIPTION
*Issue #, if available:*
Continues #100 and #102 

*Description of changes:*
Removes `_scale_to_precision` because it's a simple `Decimal.scaleb` and its bounds verification logic is unnecessary. Removes `_fractional_seconds_to_microseconds` because it's a one-liner used in one place and can be adequately explained with a line comment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
