### PR TITLE
Makes the Timestamp constructor comply with the contract stated in its docstring; simplifies Timestamp writing logic where possible.

### DIFF
--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -702,9 +702,6 @@ def _timestamp_factory(data):
             fraction = None
         else:
             fraction = _parse_decimal(buf)
-            if fraction < 0 or fraction >= 1:
-                raise IonException(
-                    'Timestamp has a fractional component out of bounds: %s' % fraction)
             fraction_exponent = fraction.as_tuple().exponent
             if fraction == 0 and fraction_exponent > -1:
                 # According to the spec, fractions with coefficients of zero and exponents >= zero are ignored.

--- a/amazon/ion/reader_text.py
+++ b/amazon/ion/reader_text.py
@@ -874,7 +874,6 @@ def _parse_timestamp(tokens):
         off_hour = tokens[_TimestampState.OFF_HOUR]
         off_minutes = tokens[_TimestampState.OFF_MINUTE]
         fraction = None
-        fraction_digits = None
         if off_hour is not None:
             assert off_minutes is not None
             off_sign = -1 if _MINUS in off_hour else 1

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -164,20 +164,14 @@ class IonPyTimestamp(Timestamp, _IonNature):
 
     @staticmethod
     def _to_constructor_args(ts):
-        try:
-            fractional_precision = getattr(ts, TIMESTAMP_FRACTION_PRECISION_FIELD)
-        except AttributeError:
-            fractional_precision = MICROSECOND_PRECISION
-        fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
-        precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, TimestampPrecision.SECOND)
-        if fractional_seconds is not None:
+        if isinstance(ts, Timestamp):
             args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, None, ts.tzinfo)
-            fractional_precision = None
+            fractional_seconds = getattr(ts, TIMESTAMP_FRACTIONAL_SECONDS_FIELD, None)
+            precision = getattr(ts, TIMESTAMP_PRECISION_FIELD, TimestampPrecision.SECOND)
+            kwargs = {TIMESTAMP_PRECISION_FIELD: precision, TIMESTAMP_FRACTIONAL_SECONDS_FIELD: fractional_seconds}
         else:
             args = (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond, ts.tzinfo)
-        kwargs = {TIMESTAMP_PRECISION_FIELD: precision, TIMESTAMP_FRACTION_PRECISION_FIELD: fractional_precision,
-                  TIMESTAMP_FRACTIONAL_SECONDS_FIELD: fractional_seconds}
-
+            kwargs = {TIMESTAMP_PRECISION_FIELD: TimestampPrecision.SECOND}
         return args, kwargs
 
 

--- a/tests/test_writer_binary_raw.py
+++ b/tests/test_writer_binary_raw.py
@@ -127,14 +127,6 @@ _P_FAILURES = [
             _E(_ET.VERSION_MARKER)
         ],
         expected=TypeError
-    ),
-    _P(
-        desc="INSUFFICIENT TIMESTAMP PRECISION",
-        events=[
-            _E(_ET.SCALAR, _IT.TIMESTAMP,
-               timestamp(1, 1, 1, 1, 1, 1, 123456, precision=TimestampPrecision.SECOND, fractional_precision=3))
-        ],
-        expected=ValueError
     )
 ]
 

--- a/tests/writer_util.py
+++ b/tests/writer_util.py
@@ -159,6 +159,53 @@ SIMPLE_SCALARS_MAP_TEXT = {
         (_DT(2016, 1, 1, 12, 34, 12, tzinfo=OffsetTZInfo()), b'2016-01-01T12:34:12.000000Z'),
         (_DT(2016, 1, 1, 12, 34, 12, tzinfo=OffsetTZInfo(timedelta(hours=-7))),
             b'2016-01-01T12:34:12.000000-07:00'),
+        (timestamp(year=1, month=1, day=1, precision=TimestampPrecision.DAY), b'0001-01-01T'),
+        (timestamp(year=1, month=1, day=1, off_minutes=-1, precision=TimestampPrecision.SECOND),
+         b'0001-01-01T00:00:00-00:01'),
+        (
+            timestamp(year=1, month=1, day=1, hour=0, minute=0, second=0,
+                      microsecond=1, precision=TimestampPrecision.SECOND),
+            b'0001-01-01T00:00:00.000001-00:00'
+        ),
+        (
+            timestamp(year=1, month=1, day=1, hour=0, minute=0, second=0,
+                      microsecond=100000, precision=TimestampPrecision.SECOND, fractional_precision=1),
+            b'0001-01-01T00:00:00.1-00:00'
+        ),
+        (timestamp(2016, precision=TimestampPrecision.YEAR), b'2016T'),
+        (timestamp(2016, off_hours=0, precision=TimestampPrecision.YEAR), b'2016T'),
+        (
+            timestamp(2016, 2, 1, 0, 1, off_minutes=1, precision=TimestampPrecision.MONTH),
+            b'2016-02T'
+        ),
+        (
+            timestamp(2016, 2, 1, 23, 0, off_hours=-1, precision=TimestampPrecision.DAY),
+            b'2016-02-01T'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, off_hours=-7, precision=TimestampPrecision.MINUTE),
+            b'2016-02-02T00:00-07:00'
+        ),
+        (
+           timestamp(2016, 2, 2, 0, 0, 30, off_hours=-7, precision=TimestampPrecision.SECOND),
+           b'2016-02-02T00:00:30-07:00'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, 1000, off_hours=-7,
+                      precision=TimestampPrecision.SECOND),
+            # When fractional_precision not specified, defaults to 6 (same as regular datetime).
+            b'2016-02-02T00:00:30.001000-07:00'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, 1000, off_hours=-7,
+                      precision=TimestampPrecision.SECOND, fractional_precision=3),
+            b'2016-02-02T00:00:30.001-07:00'
+        ),
+        (
+            timestamp(2016, 2, 2, 0, 0, 30, 100000, off_hours=-7,
+                      precision=TimestampPrecision.SECOND, fractional_precision=1),
+            b'2016-02-02T00:00:30.1-07:00'
+        ),
         (
             timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
                       fractional_seconds=Decimal('0.000010000')),


### PR DESCRIPTION
*Issue #, if available:*
Continues #100

*Description of changes:*
* In the `Timestamp` docstring:
    * Explicitly states that `fractional_seconds=Decimal(0)` is equivalent to having no precision past seconds. 
    * Clarifies that under all circumstances, a constructed `Timestamp` will have populated values for `microsecond`, `fractional_precision`, and `fractional_seconds`.
* Makes the `Timestamp` constructor comply with the contract laid out in the docstring.
* Allows `microsecond` to be specified as either a positional or a keyword argument.
* Fixes the range checking for `fractional_precision` and `fractional_seconds` and the associated tests.
* Removes all defaulting logic from the `timestamp` function. In previous revisions this defaulting led to incongruity between results of `Timestamp` and `timestamp` given the same arguments.
* Removes validation in several places that is redundant now that it is performed as part of the `Timestamp` constructor contract.
* Writes timestamp fractional seconds using `fractional_seconds` whenever the value is a `Timestamp` since this is guaranteed to be populated after construction.
* Adds some additional test coverage and improves the organization of `test_timestamp.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
