### PR TITLE
Corrects condition logic around sending ION_VERSION_MARKER_EVENT to writer

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -147,7 +147,7 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
     raw_writer = binary_writer(imports) if binary else text_writer(indent=indent)
     writer = blocking_writer(raw_writer, fp)
     from_type = _FROM_TYPE_TUPLE_AS_SEXP if tuple_as_sexp else _FROM_TYPE
-    if not binary and not omit_version_marker:
+    if binary or not omit_version_marker:
         writer.send(ION_VERSION_MARKER_EVENT)  # The IVM is emitted automatically in binary; it's optional in text.
     if sequence_as_stream and isinstance(obj, (list, tuple)):
         # Treat this top-level sequence as a stream; serialize its elements as top-level values, but don't serialize the


### PR DESCRIPTION
Updates logic just introduced by https://github.com/amzn/ion-python/pull/109.  The behavior is the same, but this is the correct logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
