### PR TITLE
Making simple_ion types picklable

### DIFF
--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -133,26 +133,15 @@ class _IonNature(object):
                                   annotations=self.ion_annotations, depth=depth)
 
 
-def _ion_type_for(name, base_cls):
-    class IonPyValueType(base_cls, _IonNature):
-        def __init__(self, *args, **kwargs):
-            super(IonPyValueType, self).__init__(*args, **kwargs)
-
-    IonPyValueType.__name__ = name
-    return IonPyValueType
-
-
 if six.PY2:
-    IonPyInt = _ion_type_for('IonPyInt', long)
+    IonPyInt = type('IonPyInt', (long,_IonNature), {'__module__':__name__})
 else:
-    IonPyInt = _ion_type_for('IonPyInt', int)
-
-
+    IonPyInt = type('IonPyInt', (int,_IonNature), {'__module__':__name__})
 IonPyBool = IonPyInt
-IonPyFloat = _ion_type_for('IonPyFloat', float)
-IonPyDecimal = _ion_type_for('IonPyDecimal', Decimal)
-IonPyText = _ion_type_for('IonPyText', six.text_type)
-IonPyBytes = _ion_type_for('IonPyBytes', six.binary_type)
+IonPyFloat = type('IonPyFloat', (float,_IonNature), {'__module__':__name__})
+IonPyDecimal = type('IonPyDecimal', (Decimal,_IonNature), {'__module__':__name__})
+IonPyText = type('IonPyText',(six.text_type,_IonNature), {'__module__':__name__})
+IonPyBytes = type('IonPyBytes', (six.binary_type,_IonNature), {'__module__':__name__})
 
 
 class IonPySymbol(SymbolToken, _IonNature):
@@ -213,6 +202,5 @@ def is_null(value):
     return value is None or isinstance(value, IonPyNull)
 
 
-IonPyList = _ion_type_for('IonPyList', list)
-IonPyDict = _ion_type_for('IonPyDict', Multimap)
-
+IonPyList = type('IonPyList', (list, _IonNature), {'__module__':__name__})
+IonPyDict = type('IonPyDict', (Multimap, _IonNature), {'__module__':__name__})

--- a/amazon/ion/util.py
+++ b/amazon/ion/util.py
@@ -86,6 +86,9 @@ class Enum(int):
 
     def __new__(cls, name, value):
         return int.__new__(cls, value)
+    
+    def __getnewargs__(self):
+        return (self.name, self.value)
 
     def __init__(self, name, value):
         self.name = name


### PR DESCRIPTION
Using `type` to create simple ion classes to make them picklable and also add the __getnewargs__ to Enum class to make the ion_type enums picklable

*Issue #, if available:* https://github.com/amzn/ion-python/issues/126

The error message I was getting before this change was similar to https://github.com/amzn/ion-python/issues/61 so this MR may also resolve that issue. But I do not know and I have not tested it.

*Description of changes:*
Because the `IonPyValueType` is defined in a function and not in the module scope so it is not picklable 
according to [python documentation](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled) and it seems `Enum` type was needing `__getnewargs__` function. I really need somebody who knows python well review my implementation of `__getnewargs__`. I am not sure what exactly `__getnewargs__` does and how it should be implemented. But it seems it is working. The code I tried and tested this PR with is:

```py
from amazon.ion import simpleion as ion
import multiprocessing
import pickle
from collections import OrderedDict

def process_1(return_queue):
    ion_objects = [
        (ion.IonPyList([1,2,3]),                            ion.IonType.LIST),
        (ion.IonPyDict(OrderedDict([("Hi","There")])),      ion.IonType.STRUCT),
        (ion.IonPyDict({"Hi":ion.IonPyFloat(1.0)}),         ion.IonType.STRUCT),
        (ion.IonPyDecimal(1),                               ion.IonType.DECIMAL),
        (ion.IonPyText("Test"),                             ion.IonType.STRING),
        (ion.IonPyBool(True),                               ion.IonType.BOOL),
        (ion.IonPySymbol("symbol_test", None),              ion.IonType.SYMBOL)
    ]
    for obj, obj_type in ion_objects:
        ion_object = obj
        ion_object.ion_type = obj_type
        pickle.loads(pickle.dumps(ion_object))  # direct pickling
        return_queue.put(ion_object)            # pickling is happening under the hood

class Custom:
    def __init__(self):
        self.symbolTest = ion.IonPySymbol("SOME Symbol", None)
        self.symbolTest.ion_type = ion.IonType.SYMBOL

def process_2(return_queue):
    c = Custom()
    return_queue.put(c)

if __name__== "__main__":
    for proc in [process_1, process_2]:
        print(proc.__name__)
        ctx = multiprocessing.get_context('spawn')
        return_queue = ctx.Queue()
        p = ctx.Process(target = proc, args=(return_queue,))
        p.start()
        p.join(10)
        p.terminate()
        while not return_queue.empty():
            v = return_queue.get(block=False)
            print(type(v), v)
```
I also ran the unit tests. All passed.

We need to pickle because multiprocessing is pickling objects to pass them to outside of the process. That is the main goal of this PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
