### PR TITLE
Fix: use localcontext to handle decimals of any precision

### DIFF
--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -198,7 +198,7 @@ def _parse_decimal(buf):
         with localcontext() as context:
             # Adjusting precision for taking into account arbitrarily
             # large/small numbers
-            context.prec = len(str(coefficient)) + abs(exponent)
+            context.prec = len(str(coefficient))
             value = Decimal(coefficient).scaleb(exponent)
 
     return value

--- a/amazon/ion/reader_binary.py
+++ b/amazon/ion/reader_binary.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 import six
 
 from datetime import timedelta
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from functools import partial
 from io import BytesIO
 from struct import unpack
@@ -186,6 +186,7 @@ def _parse_signed_int_components(buf):
 
 def _parse_decimal(buf):
     """Parses the remainder of a file-like object as a decimal."""
+    from decimal import localcontext
     exponent = _parse_var_int(buf, signed=True)
     sign_bit, coefficient = _parse_signed_int_components(buf)
 
@@ -194,7 +195,11 @@ def _parse_decimal(buf):
         value = Decimal((sign_bit, (0,), exponent))
     else:
         coefficient *= sign_bit and -1 or 1
-        value = Decimal(coefficient).scaleb(exponent)
+        with localcontext() as context:
+            # Adjusting precision for taking into account arbitrarily
+            # large/small numbers
+            context.prec = len(str(coefficient)) + abs(exponent)
+            value = Decimal(coefficient).scaleb(exponent)
 
     return value
 

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -188,7 +188,7 @@ def _serialize_decimal(ion_event):
     with localcontext() as context:
         # Adjusting precision for taking into account arbitrarily large/small
         # numbers
-        context.prec = len(digits) + abs(exponent)
+        context.prec = len(digits)
         coefficient = int(value.scaleb(-exponent).to_integral_value())
     if not sign and not exponent and not coefficient:
         # The value is 0d0; other forms of zero will fall through.

--- a/amazon/ion/writer_binary_raw.py
+++ b/amazon/ion/writer_binary_raw.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, localcontext
 from functools import partial
 
 import six
@@ -185,7 +185,11 @@ def _serialize_decimal(ion_event):
     value = ion_event.value
     validate_scalar_value(value, Decimal)
     sign, digits, exponent = value.as_tuple()
-    coefficient = int(value.scaleb(-exponent).to_integral_value())
+    with localcontext() as context:
+        # Adjusting precision for taking into account arbitrarily large/small
+        # numbers
+        context.prec = len(digits) + abs(exponent)
+        coefficient = int(value.scaleb(-exponent).to_integral_value())
     if not sign and not exponent and not coefficient:
         # The value is 0d0; other forms of zero will fall through.
         buf.append(_Zeros.DECIMAL)

--- a/tests/test_decimal.py
+++ b/tests/test_decimal.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at:
+#
+#    http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+# OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the
+# License.
+
+from decimal import Decimal
+from amazon.ion.simpleion import dumps, loads
+
+
+# regression test for https://github.com/amzn/ion-python/issues/132
+def test_decimal_precision():
+    from decimal import localcontext
+
+    with localcontext() as ctx:
+        # ensure test executes with the default precision
+        # (see https://docs.python.org/3.7/library/decimal.html#decimal.DefaultContext):
+        ctx.prec = 28
+
+        # decimal with 29 digits
+        decimal = Decimal('1234567890123456789012345678.9')
+        assert decimal == loads(dumps(decimal))
+        assert decimal == loads(dumps(decimal, binary=False))
+
+        # negative decimal with 29 digits
+        decimal = Decimal('-1234567890123456789012345678.9')
+        assert decimal == loads(dumps(decimal))
+        assert decimal == loads(dumps(decimal, binary=False))


### PR DESCRIPTION
*Issue #132*

*Description of changes:*
Use [`localcontext`](https://docs.python.org/3.7/library/decimal.html#decimal.localcontext) from to adjust the precision and allow any number of type `decimal` to be correctly de/serialized from/to Ion.

Also, I don't know where and how to add tests to prevent potential regression bugs. Locally I ran `python setup.py test` and all tests passed and in addition I used the following snippet:

```python
from decimal import Decimal

import amazon.ion.simpleion as ion

from hypothesis import given, example
from hypothesis.strategies import decimals

ion_decimals = decimals(allow_nan=False, allow_infinity=False)

@given(ion_decimals)
@example(Decimal('1005826281919371473355538432.5'))
def test_decimal(value):
    recovered_value = Decimal(ion.loads(ion.dumps(value)))
    assert recovered_value == value
```

But it uses Hypothesis for generating test cases and I don't know if you want to add this as a development dependency. If anyone can add tests to this PR, feel free to do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
