### PR TITLE
Issue 137, have a detail error message for missing ion_type.

### DIFF
--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -210,7 +210,7 @@ def _dump(obj, writer, from_type, field=None, in_struct=False, depth=0):
         ion_type = _ion_type(obj, from_type)
         ion_nature = False
     if ion_type is None:
-        raise IonException('ion_type \'None\' is not allowed in value: \"%s\", depth: %d, field: %s' % (repr(obj), depth, field))
+        raise IonException('Value must have a non-None ion_type: %s, depth: %d, field: %s' % (repr(obj), depth, field))
     if not null and ion_type.is_container:
         if ion_nature:
             event = obj.to_event(IonEventType.CONTAINER_START, field_name=field, in_struct=in_struct, depth=depth)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -209,6 +209,9 @@ def _dump(obj, writer, from_type, field=None, in_struct=False, depth=0):
     except AttributeError:
         ion_type = _ion_type(obj, from_type)
         ion_nature = False
+    if ion_type is None:
+        obj_str = repr(obj) if field is None else '%s: %s' % (field, repr(obj))
+        raise IonException('ion_type \'None\' is not allowed in value: \"%s\", depth: %d' % (obj_str, depth))
     if not null and ion_type.is_container:
         if ion_nature:
             event = obj.to_event(IonEventType.CONTAINER_START, field_name=field, in_struct=in_struct, depth=depth)

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -210,8 +210,7 @@ def _dump(obj, writer, from_type, field=None, in_struct=False, depth=0):
         ion_type = _ion_type(obj, from_type)
         ion_nature = False
     if ion_type is None:
-        obj_str = repr(obj) if field is None else '%s: %s' % (field, repr(obj))
-        raise IonException('ion_type \'None\' is not allowed in value: \"%s\", depth: %d' % (obj_str, depth))
+        raise IonException('ion_type \'None\' is not allowed in value: \"%s\", depth: %d, field: %s' % (repr(obj), depth, field))
     if not null and ion_type.is_container:
         if ion_nature:
             event = obj.to_event(IonEventType.CONTAINER_START, field_name=field, in_struct=in_struct, depth=depth)


### PR DESCRIPTION
### Description:
As mentioned in #137, this PR is trying to generate a detail error message for missing ion_type.

It would be easier to navigate the missing ion_type object by giving object value and its depth. In addition, if the object is inside a STRUCT, the `filed` will be the key instead of None.

&nbsp;
### Example output: 
**1. Missing `ion_sym`'s ion_type** 
```.py
from amazon.ion import simpleion as ion

ion_sym = ion.IonPySymbol('SomeSymbol', None)
# ion_sym.ion_type = ion.IonType.SYMBOL                 comment this line to produce error

ion_bytes = ion.dumps(ion_sym, binary=True)
```
**Error message:**
```.py
amazon.ion.exceptions.IonException: ion_type 'None' is not allowed in value: "IonPySymbol(text='SomeSymbol', sid=None, location=None)", depth: 0, field: None
```

**2. Missing `ion_sym`'s ion_type (inside a struct)**
```.py
from amazon.ion import simpleion as ion
from collections import OrderedDict

ion_sym = ion.IonPySymbol('SomeSymbol', None)
# ion_sym.ion_type = ion.IonType.SYMBOL                  comment this line to produce error

ion_dict = ion.IonPyDict(OrderedDict([
    ("key1", 1),
    ("key2", 2),
    ("someSymbol", ion_sym),
]))
ion_dict.ion_type = ion.IonType.STRUCT 
ion_bytes = ion.dumps(ion_dict, binary=True)
```
**Error message:** 
```.py
amazon.ion.exceptions.IonException: ion_type 'None' is not allowed in value: "IonPySymbol(text='SomeSymbol', sid=None, location=None)", depth: 1, field: someSymbol
```

**3. Missing `ion_dict`'s ion_type**
```.py
from amazon.ion import simpleion as ion
from collections import OrderedDict

ion_sym = ion.IonPySymbol('SomeSymbol', None)
ion_sym.ion_type = ion.IonType.SYMBOL

ion_dict = ion.IonPyDict(OrderedDict([
    ("key1", 1),
    ("key2", 2),
    ("someSymbol", ion_sym),
]))
# ion_dict.ion_type = ion.IonType.STRUCT                comment this line to produce error
ion_bytes = ion.dumps(ion_dict, binary=True)
```
**Error message:**
```.py
amazon.ion.exceptions.IonException: ion_type 'None' is not allowed in value: "<amazon.ion.simple_types.IonPyDict object at 0x10a232b80>", depth: 0, field: None
```

