### PR TITLE
Added support of empty string field_name.

### DIFF
--- a/amazon/ion/writer_binary.py
+++ b/amazon/ion/writer_binary.py
@@ -168,7 +168,7 @@ def _managed_binary_writer_coroutine(imports):
     def intern_symbols(event):
         field_name = event.field_name
         annotations = event.annotations
-        if field_name:
+        if field_name or field_name == '':
             event = event.derive_field_name(intern_symbol(field_name))
         if annotations:
             event = event.derive_annotations(

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -130,6 +130,18 @@ _SIMPLE_CONTAINER_MAP = {
             _Expected(b'\xD0', b'{}')
         ),
         (
+            [{u'': u''}, ],
+            _Expected(
+                bytes_of([
+                    0xDE,  # The lower nibble may vary. It does not indicate actual length unless it's 0.
+                    VARUINT_END_BYTE | 2,  # Field name 10 and value 0 each fit in 1 byte.
+                    VARUINT_END_BYTE | 10,
+                    0x80    # Empty string
+                ]),
+                b"{'':\"\"}"
+            )
+        ),
+        (
             [{u'foo': 0}, ],
             _Expected(
                 bytes_of([


### PR DESCRIPTION
### Description:

This PR worked on issue #140.

The binary writer doesn't include the case that field_name is an empty string.

&nbsp;
### TEST:
**Test code:**

```.py
from amazon.ion.simpleion import dumps

obj = {'': ''}
print(dumps(obj, binary=True))
```

**Output:** 
```
b'\xe0\x01\x00\xea\xe7\x81\x83\xde\x83\x87\xb1\x80\xde\x82\x8a\x80'
```
which is: `$ion    ion_symbol_table::{  symbols:[""]  }     {"" :  ""} `

&nbsp;
**Unit test**:

![Screen Shot 2021-02-23 at 7 46 11 PM](https://user-images.githubusercontent.com/67451029/108944548-cbc1e100-760f-11eb-801e-bdb14d0f736f.png)