### PR TITLE
Ttravis failed for pypi. (issue 142)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...
     #- python: "pypy3"
 install:
-  - "which python"
   - "pip install --upgrade setuptools"
   - "pip install -r requirements.txt"
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...
     #- python: "pypy3"
 install:
-  - "pip install --upgrade pip"
-  - "pip install -r requirements.txt"
+  - "sudo pip install -r requirements.txt"
   - "pip install ."
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...
     #- python: "pypy3"
 install:
+  - "which python"
   - "pip install --upgrade setuptools"
   - "pip install -r requirements.txt"
   - "pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...
     #- python: "pypy3"
 install:
+  - "pip install --upgrade pip"
   - "pip install -r requirements.txt"
   - "pip install ."
 script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     # pypy3 < 6.0.0 fails due to discrepancies with decimal...
     #- python: "pypy3"
 install:
-  - "sudo pip install -r requirements.txt"
+  - "pip install --upgrade setuptools"
+  - "pip install -r requirements.txt"
   - "pip install ."
 script: py.test


### PR DESCRIPTION
Worked on issue #142.

From the [log](https://travis-ci.com/github/amzn/ion-python/jobs/487953370#L280), the default version of `setuptool` is out of date that has some compatible issue.
`pip install --upgrade setuptools` solves it.