### PR TITLE
C extension supports 9 timestamp precision.

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -401,7 +401,7 @@ class Timestamp(datetime):
             * The ``precision`` field is passed as a keyword argument of the same name.
 
             * The ``fractional_precision`` field is passed as a keyword argument of the same name.
-              This field only relates to to the ``microseconds`` field and can be thought of
+              This field only relates to the ``microseconds`` field and can be thought of
               as the number of decimal digits that are significant.  This is an integer that
               that is in the closed interval ``[0, 6]``.  If ``0``, ``microseconds`` must be
               ``0`` indicating no precision below seconds.  This argument is optional and only valid
@@ -479,6 +479,7 @@ class Timestamp(datetime):
             del kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD]
 
         if fractional_seconds is not None and (fractional_precision is not None or datetime_microseconds is not None):
+            print("In python fractional_seconds is %d" % fractional_seconds)
             raise ValueError('fractional_seconds cannot be specified '
                              'when fractional_precision or microseconds are not None.')
 

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -479,7 +479,6 @@ class Timestamp(datetime):
             del kwargs[TIMESTAMP_FRACTIONAL_SECONDS_FIELD]
 
         if fractional_seconds is not None and (fractional_precision is not None or datetime_microseconds is not None):
-            print("In python fractional_seconds is %d" % fractional_seconds)
             raise ValueError('fractional_seconds cannot be specified '
                              'when fractional_precision or microseconds are not None.')
 

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1058,6 +1058,7 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
                 PyDict_SetItemString(timestamp_args, "fractional_seconds", py_fractional_seconds);
                 Py_DECREF(py_fractional_seconds);
                 Py_DECREF(py_dec_str);
+                free(dec_num);
             } else {
                 decQuadScaleB(&fraction, &fraction, decQuadFromInt32(&tmp, MICROSECOND_DIGITS), &dec_context);
                 int32_t microsecond = decQuadToInt32Exact(&fraction, &dec_context, DEC_ROUND_DOWN);

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1039,7 +1039,6 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
             decNumber tmp_number;
 
             int32_t fractional_precision = decQuadGetExponent(&fraction);
-            printf("In C fractional_precision is: %d\n", fractional_precision);
             if (fractional_precision > 0) {
                 _FAILWITHMSG(IERR_INVALID_TIMESTAMP, "Timestamp fractional precision cannot be a positive number.");
             }
@@ -1051,7 +1050,6 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
                 decQuadScaleB(&fraction, &fraction, decQuadFromInt32(&tmp, fractional_precision), &dec_context);
                 int dec = decQuadToInt32Exact(&fraction, &dec_context, DEC_ROUND_DOWN);
                 if (fractional_precision > MAX_TIMESTAMP_PRECISION) fractional_precision = MAX_TIMESTAMP_PRECISION;
-                printf("fractional_precision: %d\n", fractional_precision);
 
                 char* dec_num = malloc(fractional_precision+2);
                 dec_num[0] = '\0';

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -836,13 +836,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
             Py_DECREF(offset_timedelta);
             IONCHECK(err);
         }
-
-
-
         IONCHECK(ion_writer_write_timestamp(writer, &timestamp_value));
-
-
-
     }
     else if (PyDict_Check(obj) || PyObject_IsInstance(obj, _ionpydict_cls)) {
         if (ion_type == tid_none_INT) {
@@ -1036,7 +1030,8 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
         case ION_TS_FRAC:
         {
             decQuad fraction = timestamp_value.fraction;
-            decNumber tmp_number;
+            decQuad tmp;
+
 
             int32_t fractional_precision = decQuadGetExponent(&fraction);
             if (fractional_precision > 0) {
@@ -1044,9 +1039,7 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
             }
             fractional_precision = fractional_precision * -1;
 
-
             if (fractional_precision > MICROSECOND_DIGITS) {
-                decQuad tmp;
                 decQuadScaleB(&fraction, &fraction, decQuadFromInt32(&tmp, fractional_precision), &dec_context);
                 int dec = decQuadToInt32Exact(&fraction, &dec_context, DEC_ROUND_DOWN);
                 if (fractional_precision > MAX_TIMESTAMP_PRECISION) fractional_precision = MAX_TIMESTAMP_PRECISION;
@@ -1067,7 +1060,6 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
                 Py_DECREF(py_fractional_seconds);
 
             } else {
-                decQuad tmp;
                 decQuadScaleB(&fraction, &fraction, decQuadFromInt32(&tmp, MICROSECOND_DIGITS), &dec_context);
                 int32_t microsecond = decQuadToInt32Exact(&fraction, &dec_context, DEC_ROUND_DOWN);
 

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1059,13 +1059,6 @@ static iERR ionc_read_timestamp(hREADER hreader, PyObject** timestamp_out) {
                 char decimal[fractional_precision];
                 sprintf(decimal, "%d", dec);
                 char* dec_num = string_concatenation(2, fractional_precision, front, decimal);
-//                char* dec_num = malloc(fractional_precision+2);
-//                dec_num[0] = '\0';
-//                char* front = "0.";
-//                char decimal[fractional_precision];
-//                sprintf(decimal, "%d", dec);
-//                strcat(dec_num, front);
-//                strcat(dec_num, decimal);
 
                 PyObject* py_dec_str = PyUnicode_FromString(dec_num);
                 PyObject* py_fractional_seconds =

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1344,7 +1344,6 @@ iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_s
         {
             IONCHECK(ionc_read_timestamp(hreader, &py_value));
             ion_nature_constructor = _ionpytimestamp_fromvalue;
-
             break;
         }
         case tid_SYMBOL_INT:
@@ -1448,7 +1447,6 @@ iERR ionc_read_value(hREADER hreader, ION_TYPE t, PyObject* container, BOOL in_s
         ION_STRING_INIT(&field_name);
         ion_string_assign_cstr(&field_name, field_name_value, field_name_len);
     }
-
     ionc_add_to_container(container, final_py_value, in_struct, &field_name);
 
 fail:

--- a/tests/writer_util.py
+++ b/tests/writer_util.py
@@ -214,12 +214,12 @@ SIMPLE_SCALARS_MAP_TEXT = {
         (
             timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
                       fractional_seconds=Decimal('0.00001000')),
-            (b'2016-02-02T00:00:30.00001000-00:00', b'2016-02-02T00:00:30.000010-00:00')
+            (b'2016-02-02T00:00:30.00001000-00:00', b'2016-02-02T00:00:30.00001000-00:00')
         ),
         (
             timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
                       fractional_seconds=Decimal('0.7e-500')),
-            (b'2016-02-02T00:00:30.' + b'0' * 500 + b'7-00:00', b'2016-02-02T00:00:30.000000-00:00')
+            (b'2016-02-02T00:00:30.' + b'0' * 500 + b'7-00:00', b'2016-02-02T00:00:30.000000000-00:00')
         )
     ),
     _IT.SYMBOL: (
@@ -361,7 +361,7 @@ SIMPLE_SCALARS_MAP_BINARY = {
             timestamp(2016, 2, 2, 0, 0, 30, precision=TimestampPrecision.SECOND,
                       fractional_seconds=Decimal('0.7e-500')),
             (b'\x6B\xC0\x0F\xE0\x82\x82\x80\x80\x9E\x43\xF5\x07',
-             b'\x69\xC0\x0F\xE0\x82\x82\x80\x80\x9E\xC6')
+             b'\x69\xC0\x0F\xE0\x82\x82\x80\x80\x9E\xC9')
         )
     ),
     _IT.SYMBOL: (


### PR DESCRIPTION
## Description:
Solved #160 --- C extension supports 9 timestamp precision now. Since Python's datetime only supports microsecond precision so this change only affects ion [timestamp](https://github.com/amzn/ion-python/blob/d3ab7c0d12a76df9356b296981276480ec6a9f59/amazon/ion/core.py#L394).

**Code details:**
When reading a timestamp, if it has more than 6 precision, constructing an ion timestamp by passing [fractional_seconds](https://github.com/amzn/ion-python/blob/d3ab7c0d12a76df9356b296981276480ec6a9f59/amazon/ion/core.py#L411) argument and otherwise using microseconds as before.

When writing a timestamp to a file. Reading at most 9 decimal digits that from python ion timestamp into C decQuad and using ion-c API to dump them.

## Test:
✅ &nbsp;**Memory leak test**: No leak.
✅ &nbsp;**Performance measurement**: timeit() shows that It's almost the same speed as before.
✅ &nbsp;**Unit test**:  ![Screen Shot 2021-08-26 at 12 09 47 PM](https://user-images.githubusercontent.com/67451029/131021939-40dd04ee-8583-4a2c-a047-73a2bfa7e7e1.png)



&nbsp;
&nbsp;
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
