### PR TITLE
Update simpleion.load function to support iterating infinite streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *.pyo
+*.so
 *~
 *#
 *.swp
@@ -13,4 +14,5 @@
 /dist
 /amazon.ion.egg-info
 /docs/_build/
+/amazon/ion/ion-c-build/
 

--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -19,7 +19,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from collections import MutableMapping, MutableSequence, OrderedDict
+from collections import OrderedDict
+from collections.abc import MutableMapping, MutableSequence
 from datetime import datetime, timedelta, tzinfo
 from decimal import Decimal, ROUND_FLOOR, Context, Inexact
 from math import isnan

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -24,7 +24,7 @@ from __future__ import division
 from __future__ import print_function
 
 from decimal import Decimal
-from collections import MutableMapping
+from collections.abc import MutableMapping
 
 import six
 

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -612,6 +612,24 @@ def test_roundtrip(p):
     _assert_roundtrip(obj, res, tuple_as_sexp)
 
 
+@parametrize(
+    *tuple(_generate_roundtrips(_ROUNDTRIPS))
+)
+def test_roundtrip_ion_stream(p):
+    obj, is_binary, indent, tuple_as_sexp = p
+    expected  = [obj]
+    out = BytesIO()
+    dump(obj, out, binary=is_binary, indent=indent, tuple_as_sexp=tuple_as_sexp)
+    out.seek(0)
+    res = load(out, single_value=False, parse_eagerly=True)
+    _assert_roundtrip(expected, res, tuple_as_sexp)
+
+
+def test_ion_stream():
+    expected = "$ion_1_0 [1] (2) {a:3}"
+    result = dumps(loads(expected, single_value=False, parse_eagerly=False), binary=False)
+    assert result == expected
+
 @parametrize(True, False)
 def test_single_value_with_stream_fails(is_binary):
     out = BytesIO()


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Converted the ionc_read implementation to return and iterator instance to allow processing large ION streams without having to load entire input buffers into memory. 

Sharing this pull request to see if there's interest to see these changes merged. If so, I can work on few improvements to this changeset to add more integration tests and verify there are no memory leak with valgrind etc..

*Testing:* Tested with unit test and made sure they all pass. And used this version briefly in a separate workload to process some big files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
