### PR TITLE
Fix for compatibility with Python 3.10

### DIFF
--- a/amazon/ion/core.py
+++ b/amazon/ion/core.py
@@ -19,7 +19,15 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from collections import MutableMapping, MutableSequence, OrderedDict
+# in Python 3.10, abstract collections have moved into their own module
+# for compatibility with 3.10+, first try imports from the new location
+# if that fails, try from the pre-3.10 location
+try:
+    from collections.abc import MutableMapping, MutableSequence
+    from collections import OrderedDict
+except:
+    from collections import MutableMapping, MutableSequence, OrderedDict
+    
 from datetime import datetime, timedelta, tzinfo
 from decimal import Decimal, ROUND_FLOOR, Context, Inexact
 from math import isnan

--- a/amazon/ion/simple_types.py
+++ b/amazon/ion/simple_types.py
@@ -24,7 +24,14 @@ from __future__ import division
 from __future__ import print_function
 
 from decimal import Decimal
-from collections import MutableMapping
+
+# in Python 3.10, abstract collections have moved into their own module
+# for compatibility with 3.10+, first try imports from the new location
+# if that fails, try from the pre-3.10 location
+try:
+    from collections.abc import MutableMapping
+except:
+    from collections import MutableMapping
 
 import six
 


### PR DESCRIPTION
for 3.10 compatibility, attempt import of abstract collections from collections.abc and then from collections (for pre 3.10)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
