### PR TITLE
Fixes a setuptool version issue to setup the package during CI/CD successfully.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Create a virtual environment
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
 
-      - run: pip install --upgrade setuptools
       - run: pip install -r requirements.txt
       - run: pip install -e .
       - run: py.test

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ six==1.16.0
 toml==0.10.2
 tox==3.23.1
 virtualenv==20.4.7
+setuptools==60.5.0


### PR DESCRIPTION
By our setup logic, we install the latest setuptool which 60.6.0 has an incompatible issue. Using 60.5.0 for now.
Refer to https://github.com/amzn/ion-python/issues/191 for details.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
