### PR TITLE
Initializes variables outside of the for loop.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ def run_setup():
                     extra_link_args=['-Wl,-rpath,%s' % '$ORIGIN/ion-c-build/lib',  # LINUX
                                      '-Wl,-rpath,%s' % '@loader_path/ion-c-build/lib'  # MAC
                                      ],
+                    extra_compile_args=['-std=c99'],
                 ),
             ],
         )


### PR DESCRIPTION
**Description:**
Some C compilers complain that initializing variables within a for loop is invalid, move it outside.

**Test:**
see GHA below.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
