### PR TITLE
Fixes a timestamp precision check issue.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -646,7 +646,7 @@ iERR ionc_write_value(hWRITER writer, PyObject* obj, PyObject* tuple_as_sexp) {
         int year, month, day, hour, minute, second;
         short precision, fractional_precision;
         int final_fractional_precision, final_fractional_seconds;
-        if (PyObject_HasAttrString(obj, "precision")) {
+        if (PyObject_HasAttrString(obj, "precision") && PyObject_GetAttrString(obj, "precision") != Py_None) {
             // This is a Timestamp.
             precision = int_attr_by_name(obj, "precision");
             fractional_precision = int_attr_by_name(obj, "fractional_precision");


### PR DESCRIPTION
`PyObject_HasAttrString(obj, "precision")` returns `True` even though the precision field is `None`.

Adds one more check to make sure wether a timestamp has a precision. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
