### PR TITLE
Changes loads API to return a regular Ion python object instead of iterator.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1520,7 +1520,7 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
         FAILWITH(IERR_INVALID_ARG);
     }
 
-    // parse lazily, return an iterator
+    // Return an iterator to parse lazily.
     if (parse_eagerly == Py_False) {
         iterator = PyObject_New(ionc_read_Iterator, &ionc_read_IteratorType);
         if (!iterator) {
@@ -1546,6 +1546,10 @@ PyObject* ionc_read(PyObject* self, PyObject *args, PyObject *kwds) {
             &iterator->_reader_options)); // NULL represents default reader options
         return iterator;
     } else {
+        hREADER      reader;
+        long         size;
+        char     *buffer = NULL;
+
         PyString_AsStringAndSize(py_file, &buffer, &size);
         // TODO what if size is larger than SIZE ?
         ION_READER_OPTIONS options;

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -346,7 +346,7 @@ def load_python(fp, catalog=None, single_value=True, encoding='utf-8', cls=None,
             stream, IonException will be raised. NOTE: this means that when data is dumped using
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly (Optional[True|False]): NOTE THAT THIS FEATURE IS STILL CONSIDERED EXPERIMENTAL. Used in
-            conjunction with ``single_value=False`` to return the result as list or an iterator
+            conjunction with ``single_value=False`` to return the result as list or an iterator.
         encoding: NOT IMPLEMENTED
         cls: NOT IMPLEMENTED
         object_hook: NOT IMPLEMENTED
@@ -463,7 +463,7 @@ def loads(ion_str, catalog=None, single_value=True, encoding='utf-8', cls=None, 
             the Ion stream, IonException will be raised. NOTE: this means that when data is dumped using
             ``sequence_as_stream=True``, it must be loaded using ``single_value=False``. Default: True.
         parse_eagerly (Optional[True|False]): NOTE THAT THIS FEATURE IS STILL CONSIDERED EXPERIMENTAL. Used in
-            conjunction with ``single_value=False`` to return the result as list or an iterator
+            conjunction with ``single_value=False`` to return the result as list or an iterator.
         encoding: NOT IMPLEMENTED
         cls: NOT IMPLEMENTED
         object_hook: NOT IMPLEMENTED
@@ -506,9 +506,9 @@ def load_extension(fp, single_value=True, parse_eagerly=True, encoding='utf-8'):
     if parse_eagerly:
         data = fp.read()
         data = data if isinstance(data, bytes) else bytes(data, encoding)
-        return ionc.ionc_read(data, single_value=single_value, emit_bare_values=False, parse_eagerly=parse_eagerly)
+        return ionc.ionc_read(data, single_value=single_value, emit_bare_values=False, parse_eagerly=True)
     else:
-        iterator = ionc.ionc_read(fp, emit_bare_values=False, parse_eagerly=parse_eagerly)
+        iterator = ionc.ionc_read(fp, single_value=single_value, emit_bare_values=False, parse_eagerly=False)
         if single_value:
             try:
                 value = next(iterator)
@@ -520,6 +520,7 @@ def load_extension(fp, single_value=True, parse_eagerly=True, encoding='utf-8'):
             except StopIteration:
                 pass
             return value
+        return iterator
 
 
 def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=False, ensure_ascii=True,
@@ -542,7 +543,7 @@ def dump(obj, fp, imports=None, binary=True, sequence_as_stream=False, skipkeys=
 
 
 def load(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
-         parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=False, **kw):
+         parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True, **kw):
     if c_ext and catalog is None:
         return load_extension(fp, single_value=single_value, parse_eagerly=parse_eagerly, encoding=encoding)
     else:

--- a/amazon/ion/simpleion.py
+++ b/amazon/ion/simpleion.py
@@ -305,7 +305,7 @@ def dumps(obj, imports=None, binary=True, sequence_as_stream=False, skipkeys=Fal
 
 
 def load_python(fp, catalog=None, single_value=True, encoding='utf-8', cls=None, object_hook=None, parse_float=None,
-        parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=False, **kw):
+        parse_int=None, parse_constant=None, object_pairs_hook=None, use_decimal=None, parse_eagerly=True, **kw):
     """Deserialize ``fp`` (a file-like object), which contains a text or binary Ion stream, to a Python object using the
     following conversion table::
         +-------------------+-------------------+
@@ -502,13 +502,13 @@ def dump_extension(obj, fp, binary=True, sequence_as_stream=False, tuple_as_sexp
     fp.write(res)
 
 
-def load_extension(fp, single_value=True, parse_eagerly=False, encoding='utf-8'):
+def load_extension(fp, single_value=True, parse_eagerly=True, encoding='utf-8'):
     if parse_eagerly:
         data = fp.read()
         data = data if isinstance(data, bytes) else bytes(data, encoding)
-        return ionc.ionc_read(data, single_value=single_value, emit_bare_values=False, parse_eagerly=True)
+        return ionc.ionc_read(data, single_value=single_value, emit_bare_values=False, parse_eagerly=parse_eagerly)
     else:
-        iterator = ionc.ionc_read(fp, emit_bare_values=False, parse_eagerly=True)
+        iterator = ionc.ionc_read(fp, emit_bare_values=False, parse_eagerly=parse_eagerly)
         if single_value:
             try:
                 value = next(iterator)


### PR DESCRIPTION
### Description:

[`parse_eagerly`](https://github.com/amzn/ion-python/blob/master/amazon/ion/simpleion.py#L348) is an option to allow users to return an iterator to read a large Ion file incrementally. 

Currently `simpleion.loads()` returns an iterator when `parse_eagerly` is set to False. And still leverage the iterator to gather all Ion values and store them within a list when `parse_eagerly` is set to True. In other words we always rely on the iterator to return Ion objects. 

I found that some issues are related to iterator's [safe-guarding logic](https://github.com/amzn/ion-python/blob/master/amazon/ion/ioncmodule.c#L1429-L1432) and I opened an issue for them - https://github.com/amzn/ion-python/issues/213. So I decide to fall back some logic to avoid always using a custom iterator.

So after this change,
People can set `parse_eagerly` to `False` to get an iterator to read Ion file incrementally, or
They can set `parse_eagerly` to `True` to ask parser to read the whole file and convert it to python objects directly.

And additionally I emphasized that the `parse_eagerly` feature is [considered experimental](https://github.com/amzn/ion-python/pull/214/files#diff-d1d51f1c2772ccb406bf2685992d2ddb9b4fe93643d36d2c5232c9b82ddd33a7R348) until it's more stable.

### Test:
Unit test, and manually testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
