### PR TITLE
Adjests read buffer size to avoid unicode/utf-8 conversion issue.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -1427,7 +1427,7 @@ iERR ion_read_file_stream_handler(struct _ion_user_stream *pstream) {
 
     // safe-guarding the size variable to protect memcpy bounds
     if (size < 0  || size > IONC_STREAM_READ_BUFFER_SIZE) {
-        _FAILWITHMSG(IERR_READ_ERROR, "illegal bytes number has been read");
+        FAILWITH(IERR_READ_ERROR);
     }
     memcpy(stream_handle->buffer, char_buffer, size);
 

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -21,7 +21,7 @@
 #define FIELD_NAME_MAX_LEN 1000
 #define ANNOTATION_MAX_LEN 50
 
-#define IONC_STREAM_READ_BUFFER_SIZE 1024
+#define IONC_STREAM_READ_BUFFER_SIZE 1024*32
 
 static char _err_msg[ERR_MSG_MAX_LEN];
 
@@ -1669,7 +1669,8 @@ PyObject* ionc_init_module(void) {
 
     decContextDefault(&dec_context, DEC_INIT_DECQUAD);  //The writer already had one of these, but it's private.
 
-    _arg_read_size = PyLong_FromLong(IONC_STREAM_READ_BUFFER_SIZE);
+    // Divide by four to avoid size overflow due to Unicode and UTF-8 conversion
+    _arg_read_size = PyLong_FromLong(IONC_STREAM_READ_BUFFER_SIZE/4);
     return m;
 }
 

--- a/tests/test_simpleion.py
+++ b/tests/test_simpleion.py
@@ -704,3 +704,13 @@ def test_dumps_omit_version_marker():
     assert dumps(v) == b'\xe0\x01\x00\xea\x21\x05'
     assert dumps(v, omit_version_marker=True) == b'\xe0\x01\x00\xea\x21\x05'
 
+
+# See issue https://github.com/amzn/ion-python/issues/213
+def test_loads_unicode_utf8_conversion():
+    # Generates test data that more than 1024*32 bytes
+    data = "[ '''\u2013''',"
+    data += 'test,' * 100000
+    data += "]"
+    # Loads API should convert it to UTF-8 without illegal bytes number read exception.
+    loads(data, parse_eagerly=True)
+


### PR DESCRIPTION
### Issue 
This PR fixes https://github.com/amzn/ion-python/issues/213 and https://github.com/amzn/ion-python/issues/205

### Description: 
The root is because of unicode and UTF-8 conversion. 
For example, when we read a String IO including value `\u2013` by `fp.read(1)`, It will be converted to 3 bytes instead 1 later.
which failed [memory bounds check](https://github.com/amzn/ion-python/blob/master/amazon/ion/ioncmodule.c#L1429-L1432). 

Unicode detail, see https://www.fileformat.info/info/unicode/char/2013/index.htm

### Solution
To avoid this, we maintain a 1024x32 bytes buffer, and only read 1024*32/4 bytes each time (since one code point can be up to 4 UTF-8 bytes)

### Benchmark
The performance depends on the size of files we are going to read. On the one hand, if the file is really small but we maintain a large buffer, it’s not efficient and slower in performance. On the other hand, if the file is really large but we only read a small number of bytes, say 32 bytes, each time it’s also very slow. I use 32*1024 first and we should eventually allow user to configure read buffer size for their user case in the future.

I opened an issue to keep this on track - https://github.com/amzn/ion-python/issues/215

### Test
Passed unit test, and run specific test cases that cause the issue. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
