### PR TITLE
Remove Python 3.6 from Builds, Bump Minor Version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python-version: ['3.7', '3.8', '3.9', '3.10', 'pypy-3.7', 'pypy-3.8']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for Python.
 [![Build Status](https://travis-ci.org/amzn/ion-python.svg?branch=master)](https://travis-ci.org/amzn/ion-python)
 [![Documentation Status](https://readthedocs.org/projects/ion-python/badge/?version=latest)](https://ion-python.readthedocs.io/en/latest/?badge=latest)
 
-This package is designed to work with **Python 3.6+**
+This package is designed to work with **Python 3.6** and above. Sunsetted versions may not be supported once they are 6 months or more past EOL.
 
 ## Getting Started
 
@@ -81,13 +81,13 @@ installed Python (`requirements.txt` installs `tox`).
 Install relevant versions of Python:
 
 ```
-$ for V in 3.6.13 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5; do pyenv install $V; done
+$ for V in 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5; do pyenv install $V; done
 ```
 
 Once you have these installations, add them as a local `pyenv` configuration
 
 ```
-$ pyenv local 3.6.13 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5
+$ pyenv local 3.7.10 3.8.10 3.9.5 pypy3.7-7.3.5
 ```
 
 Assuming you have `pyenv` properly set up (making sure `pyenv init` is evaluated into your shell),

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for Python.
 [![Build Status](https://travis-ci.org/amzn/ion-python.svg?branch=master)](https://travis-ci.org/amzn/ion-python)
 [![Documentation Status](https://readthedocs.org/projects/ion-python/badge/?version=latest)](https://ion-python.readthedocs.io/en/latest/?badge=latest)
 
-This package is designed to work with **Python 3.6** and above. Sunsetted versions may not be supported once they are 6 months or more past EOL.
+This package is designed to work with **Python 3**. It is intended to work with all stable minor versions. Newer language features will be used as deemed valuable. Support may be dropped for versions more than six months past EOL. 
 
 ## Getting Started
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def run_setup():
 
     setup(
         name='amazon.ion',
-        version='0.10.3',
+        version='0.10.1',
         description='A Python implementation of Amazon Ion.',
         url='http://github.com/amzn/ion-python',
         author='Amazon Ion Team',

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def run_setup():
 
     setup(
         name='amazon.ion',
-        version='0.9.3',
+        version='0.10.3',
         description='A Python implementation of Amazon Ion.',
         url='http://github.com/amzn/ion-python',
         author='Amazon Ion Team',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,pypy3
+envlist = py37,py38,py39,pypy3
 
 [testenv]
 requires= pip >= 21.1.2


### PR DESCRIPTION
This change move the oldest supported version of Python to 3.7.
Python 3.6 is now a year past EOL and is no longer supported on the
ubuntu images used for github builds.

This also bumps the *minor* version number. While there are no current
changes that _shouldn't_ work on 3.6, future changes may not.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
