### PR TITLE
Drop python 2 support in C extension.

### DIFF
--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -31,10 +31,6 @@ static char _err_msg[ERR_MSG_MAX_LEN];
 #define IONC_BYTES_FORMAT "y#"
 #define IONC_READ_ARGS_FORMAT "OO"
 
-#if PY_VERSION_HEX < 0x02070000
-    #define offset_seconds(x) offset_seconds_26(x)
-#endif
-
 static PyObject* _math_module;
 
 static PyObject* _decimal_module;
@@ -126,15 +122,6 @@ static int int_attr_by_name(PyObject* obj, char* attr_name) {
     }
     Py_DECREF(py_int);
     return c_int;
-}
-
-// TODO compare performance of these offset_seconds* methods. The _26 version will work with all versions, so if it is
-// as fast, should be used for all.
-static int offset_seconds_26(PyObject* timedelta) {
-    long microseconds = int_attr_by_name(timedelta, "microseconds");
-    long seconds_microseconds = (long)int_attr_by_name(timedelta, "seconds") * 1000000;
-    long days_microseconds = (long)int_attr_by_name(timedelta, "days") * 24 * 3600 * 1000000;
-    return (microseconds + seconds_microseconds + days_microseconds) / 1000000;
 }
 
 static int offset_seconds(PyObject* timedelta) {

--- a/amazon/ion/ioncmodule.c
+++ b/amazon/ion/ioncmodule.c
@@ -124,6 +124,7 @@ static int int_attr_by_name(PyObject* obj, char* attr_name) {
     return c_int;
 }
 
+// an Alternative to calculate timedelta, see https://github.com/amzn/ion-python/issues/225
 static int offset_seconds(PyObject* timedelta) {
     PyObject* py_seconds = PyObject_CallMethod(timedelta, "total_seconds", NULL);
     PyObject* py_seconds_int = PyObject_CallMethod(py_seconds, "__int__", NULL);


### PR DESCRIPTION
## Description
Drop the support of python 2 in C extension.  

One thing need need to be done in this PR is benchmarking utcoffset calculation, details see [comment](https://github.com/amzn/ion-python/blob/master/amazon/ion/ioncmodule.c#L145-L146). 

 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
