### PR TITLE
Fix release workflow and bump version to 0.14.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         run: git submodule init && git submodule update && python3 -m venv ./venv && . venv/bin/activate
       - run: python -m pip install build
       - run: python -m build .
-      - run: python -m pip install -e .
+      - run: python -m pip install -e '.[test]'
       - run: py.test --ignore tests/test_benchmark_cli.py --ignore tests/test_benchmark_spec.py
 
   source-distribution:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### 0.14.1 (2026-06-05)
+* Fix release workflow to install test dependencies (#431)
+* Updates ion-c submodule
+
 ### 0.14.0 (2026-04-22)
 * Bump minimum Python version to 3.9 (#406)
 * Migrate to pyproject.toml (#379)

--- a/src-python/amazon/__init__.py
+++ b/src-python/amazon/__init__.py
@@ -15,6 +15,6 @@
 """
 Amazon Ion
 """
-__version__ = "0.13.0"
+__version__ = "0.14.1"
 from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)

--- a/src-python/amazon/ion/__init__.py
+++ b/src-python/amazon/ion/__init__.py
@@ -12,7 +12,7 @@
 # specific language governing permissions and limitations under the
 # License.
 __author__ = 'Amazon.com, Inc.'
-__version__ = '0.14.0'
+__version__ = '0.14.1'
 
 __all__ = [
     'core',


### PR DESCRIPTION
The v0.14.0 release failed because the test job installed the package without test dependencies, so pytest was never available. Install with `.[test]` to include pytest.

Also fix the version in `src-python/amazon/__init__.py` which was still at 0.13.0 — this caused the build to produce 0.13.0 artifacts from the v0.14.0 tag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
