### PR TITLE
Fix release workflow pypy version: pypy-3.8 to pypy-3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.8']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.10']
     steps:
       - uses: actions/checkout@v4
       - name: Set up python

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ### 0.14.1 (2026-06-05)
 * Fix release workflow to install test dependencies (#431)
+* Fix release workflow pypy version: pypy-3.8 to pypy-3.10 (#432)
 * Updates ion-c submodule
 
 ### 0.14.0 (2026-04-22)


### PR DESCRIPTION
PyPy 3.8 is EOL and setuptools 78.1.1 doesn't publish wheels for it, causing the release workflow to fail. Align with main.yml which already uses pypy-3.10.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
