### PR TITLE
Fix py build cmake version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ### 0.14.1 (2026-06-05)
 * Fix release workflow to install test dependencies (#431)
 * Fix release workflow pypy version: pypy-3.8 to pypy-3.10 (#432)
+* Bump py-build-cmake from ~=0.1.8 to ~=0.5.0 (#433)
 * Updates ion-c submodule
 
 ### 0.14.0 (2026-04-22)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dev = [
 
 # Build System ################################################################################
 [build-system]
-requires = ["py-build-cmake~=0.1.8"]
+requires = ["py-build-cmake~=0.5.0"]
 build-backend = "py_build_cmake.build"
 
 # py-build-cmake ##############################################################################


### PR DESCRIPTION
`py-build-cmake 0.1.8` requires `distlib~=0.3.5`, which conflicts with cibuildwheel v3.x that constrains `distlib==0.4.0`. This broke the wheel build stage of the release workflow. `py-build-cmake 0.5.0` requires `distlib~=0.4.0`, resolving the conflict.

Verified locally: build succeeds and all tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
