### PR TITLE
Fix release workflow: checkout submodules for wheel and sdist builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
         python-version: [ '3.10' ]
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Build sdist
         run: python -m pip install build && python -m build -s
@@ -60,30 +62,6 @@ jobs:
           zip ion-python-source ./dist/amazon_ion-*.tar.gz
           aws s3 mv ion-python-source.zip ${{ secrets.AWS_SOURCE_BUCKET_URL }} --acl bucket-owner-full-control
 
-      - name: Install the released source from PYPI
-        run: |
-          sleep 300s
-
-          for (( i=0; i<3; i++ ))
-          do
-            v=""
-
-            if ! (pip install --no-binary :all: "amazon.ion==${GITHUB_REF##*/v}") then
-              echo "Unable to install the desired version"
-              sleep 120s
-              continue
-            fi
-
-            v=$( pip show amazon.ion | grep Version )
-            break
-          done
-
-          if [[ $v != "Version: ${GITHUB_REF##*/v}" ]]
-          then
-            echo "Exiting because unable to install the new version from PYPI"
-            exit 1
-          fi
-
   build-wheels:
     name: Build wheels on ${{ matrix.os }}
     if: startsWith(github.ref, 'refs/tags/')
@@ -107,6 +85,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up QEMU for Linux Builds
         if: runner.os == 'Linux'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 * Fix release workflow to install test dependencies (#431)
 * Fix release workflow pypy version: pypy-3.8 to pypy-3.10 (#432)
 * Bump py-build-cmake from ~=0.1.8 to ~=0.5.0 (#433)
+* Fix release workflow: checkout submodules for wheel and sdist builds (#434)
 * Updates ion-c submodule
 
 ### 0.14.0 (2026-04-22)


### PR DESCRIPTION
The build-wheels and source-distribution jobs used actions/checkout without submodules, so src/ion-c/ was empty and CMake failed with "does not contain a CMakeLists.txt file".

Also remove the PyPI verification step from source-distribution — it tried to pip install from PyPI before anything was published there (upload-wheels runs later), so it always failed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
