### PR TITLE
Fix ion-c submodule missing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,12 @@ jobs:
         with:
           submodules: true
 
+      # ion-c derives its version via `git describe --tags --match "v*"`. Submodule
+      # checkouts don't fetch tags, so without this the version macros expand to empty
+      # and ion_version.c fails to compile ("expected expression before ';' token").
+      - name: Fetch ion-c tags
+        run: git -C src/ion-c fetch --tags
+
       - name: Set up QEMU for Linux Builds
         if: runner.os == 'Linux'
         uses: docker/setup-qemu-action@v3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### (unreleased)
+* Fix ion-c submodule missing tags (#435)
+
 ### 0.14.1 (2026-06-05)
 * Fix release workflow to install test dependencies (#431)
 * Fix release workflow pypy version: pypy-3.8 to pypy-3.10 (#432)


### PR DESCRIPTION
*Description of changes:*

Currently, ion-python release fails, see https://github.com/amazon-ion/ion-python/actions/runs/27044538198 . [ubuntu-latest build](https://github.com/amazon-ion/ion-python/actions/runs/27044538198/job/79827850880) fails because `IONC_VERSION_MAJOR`, `IONC_VERSION_MINOR`, and `IONC_VERSION_PATCH` are all undefined.

Those constants are set in https://github.com/amazon-ion/ion-c/blob/3132373af6e326bb9e32dbbc2310c98b70559316/build_version.h.in#L5-L7 via [match](https://github.com/amazon-ion/ion-c/blob/3132373af6e326bb9e32dbbc2310c98b70559316/cmake/VersionHeader.cmake#L15) on [git tags](https://github.com/amazon-ion/ion-c/blob/3132373af6e326bb9e32dbbc2310c98b70559316/cmake/VersionHeader.cmake#L3)

GitHub checkout action does shallow clone, and there is no way to override is per submodule. This PR adds a manual step to the release process to fetch tags.

Local test:
```shell
❯ git submodule update --init --depth=1 ion-c
Submodule 'ion-c' (https://github.com/amazon-ion/ion-c) registered for path 'ion-c'
Cloning into '/workplace/mnazaren/ion-python/src/ion-c'...
Submodule path 'ion-c': checked out '3132373af6e326bb9e32dbbc2310c98b70559316'
❯ cd ion-c
❯ git log
commit 3132373af6e326bb9e32dbbc2310c98b70559316 (grafted, HEAD, origin/master, origin/HEAD, master)
Author: Tyler Gregg <greggt@amazon.com>
Date:   Wed May 13 14:23:21 2026 -0700

    Additional overflow hardening
❯ git tag
❯ git fetch --tags
remote: Enumerating objects: 2111, done.
remote: Counting objects: 100% (2111/2111), done.
remote: Compressing objects: 100% (547/547), done.
remote: Total 1955 (delta 1542), reused 1726 (delta 1379), pack-reused 0 (from 0)
Receiving objects: 100% (1955/1955), 625.40 KiB | 7.63 MiB/s, done.
Resolving deltas: 100% (1542/1542), completed with 132 local objects.
From https://github.com/amazon-ion/ion-c
 * [new tag]         v1.0.0     -> v1.0.0
 * [new tag]         v1.0.1     -> v1.0.1
 * [new tag]         v1.0.2     -> v1.0.2
 * [new tag]         v1.0.3     -> v1.0.3
 * [new tag]         v1.0.4     -> v1.0.4
 * [new tag]         v1.0.5     -> v1.0.5
 * [new tag]         v1.0.6     -> v1.0.6
 * [new tag]         v1.1.0     -> v1.1.0
 * [new tag]         v1.1.1     -> v1.1.1
 * [new tag]         v1.1.2     -> v1.1.2
 * [new tag]         v1.1.3     -> v1.1.3
 * [new tag]         v1.1.4     -> v1.1.4
 * [new tag]         v1.4.0     -> v1.4.0
 ❯ git tag
v1.0.0
v1.0.1
v1.0.2
v1.0.3
v1.0.4
v1.0.5
v1.0.6
v1.1.0
v1.1.1
v1.1.2
v1.1.3
v1.1.4
v1.4.0
❯ git describe --long --tags --dirty --match "v*"
v0.14.1-1-g87bf307
❯ git log
commit 3132373af6e326bb9e32dbbc2310c98b70559316 (grafted, HEAD, origin/master, origin/HEAD, master)
Author: Tyler Gregg <greggt@amazon.com>
Date:   Wed May 13 14:23:21 2026 -0700

    Additional overflow hardening
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
