### PR TITLE
Trigger release workflow when release is released

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Ion Python Release
 
 on:
   release:
-    types: [ created ]
+    types: [ released ]
 
 jobs:
   test:


### PR DESCRIPTION
*Description of changes:*

This PR changes release workflow trigger from [created](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=created#release)
> A draft was saved, or a release or pre-release was published without previously being saved as a draft.

to [released](https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release)
> A release was published, or a pre-release was changed to a release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
