### PR TITLE
Unshallow ion-c submodule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       # checkouts don't fetch tags, so without this the version macros expand to empty
       # and ion_version.c fails to compile ("expected expression before ';' token").
       - name: Fetch ion-c tags
-        run: git -C src/ion-c fetch --tags
+        run: git -C src/ion-c fetch --tags --unshallow
 
       - name: Set up QEMU for Linux Builds
         if: runner.os == 'Linux'

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### (unreleased)
+* Unshallow ion-c submodule (#438)
+
 ### 0.14.2 (2026-06-23)
 * Fix ion-c submodule missing tags (#435)
 


### PR DESCRIPTION
*Description of changes:*

Unshallow ion-c submodule to fix `git describe` failure during release workflow, [example failure](https://github.com/amazon-ion/ion-python/actions/runs/28048126652/job/83031762089)

Local test:
```shell
❯ git tag
❯ git describe --long --tags --dirty --match "v*"
fatal: No names found, cannot describe anything.
❯ git remote
origin
❯ git fetch --tags --unshallow
remote: Enumerating objects: 2122, done.
remote: Counting objects: 100% (2122/2122), done.
remote: Compressing objects: 100% (556/556), done.
remote: Total 1965 (delta 1548), reused 1729 (delta 1380), pack-reused 0 (from 0)
Receiving objects: 100% (1965/1965), 627.19 KiB | 4.29 MiB/s, done.
Resolving deltas: 100% (1548/1548), completed with 132 local objects.
From https://github.com/amazon-ion/ion-c
 * [new tag]         v1.0.0     -> v1.0.0
 * [new tag]         v1.0.1     -> v1.0.1
 * [new tag]         v1.0.2     -> v1.0.2
 * [new tag]         v1.0.3     -> v1.0.3
 * [new tag]         v1.0.4     -> v1.0.4
 * [new tag]         v1.0.5     -> v1.0.5
 * [new tag]         v1.0.6     -> v1.0.6
 * [new tag]         v1.1.0     -> v1.1.0
 * [new tag]         v1.1.1     -> v1.1.1
 * [new tag]         v1.1.2     -> v1.1.2
 * [new tag]         v1.1.3     -> v1.1.3
 * [new tag]         v1.1.4     -> v1.1.4
 * [new tag]         v1.4.0     -> v1.4.0
❯ git describe --long --tags --dirty --match "v*"
v1.1.4-3-g3132373
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
