### PR TITLE
Update macOS target versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,10 @@ jobs:
       matrix:
         include:
           # See https://cibuildwheel.readthedocs.io/en/stable/options/#build-skip for more details.
-          - os: macos-13 # macos-13 is the last non-large x86-based runner. Need to look into cross-compiling.
+          - os: macos-26-intel
             arch: x86_64
             cibw_arch: "x86_64"
-          - os: macos-14  # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+          - os: macos-latest
             arch: arm64
             cibw_arch: "arm64"
           - os: windows-latest

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+### (unreleased)
+* Update macOS target versions
+
 ### 0.14.3 (2026-06-24)
 * Unshallow ion-c submodule (#438)
 


### PR DESCRIPTION
*Description of changes:*

macos-13 runners are removed: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ . This PR updates macOS runner to latest Intel and ARM versions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
