### PR TITLE
Fix PYPI installation check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
               continue
             fi
 
-            v=$( pip show amazon.ion | grep Version )
+            v=$( pip show amazon.ion | grep Version | head -1 )
             break
           done
 


### PR DESCRIPTION
*Description of changes:*

This PR fixes PYPI installation check at the end of release workflow. Currently, the check [fails](https://github.com/amazon-ion/ion-python/actions/runs/28137676061/job/83332093037), even though the version was released to PYPI: https://pypi.org/project/amazon-ion/0.14.4/ .

Local test:
```
❯ pip install --only-binary :all: "amazon.ion==0.14.4"
Collecting amazon.ion==0.14.4
  Downloading amazon_ion-0.14.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (18 kB)
Collecting attrs==21.2.0 (from amazon.ion==0.14.4)
  Using cached attrs-21.2.0-py2.py3-none-any.whl.metadata (9.1 kB)
Collecting setuptools==78.1.1 (from amazon.ion==0.14.4)
  Using cached setuptools-78.1.1-py3-none-any.whl.metadata (6.5 kB)
Collecting jsonconversion==1.2.1 (from amazon.ion==0.14.4)
  Using cached jsonconversion-1.2.1-py3-none-any.whl.metadata (5.7 kB)
Collecting pyparsing==3.2.5 (from amazon.ion==0.14.4)
  Using cached pyparsing-3.2.5-py3-none-any.whl.metadata (5.0 kB)
Collecting numpy<3.0,>=1.23 (from jsonconversion==1.2.1->amazon.ion==0.14.4)
  Downloading numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
Downloading amazon_ion-0.14.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (573 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 573.7/573.7 kB 17.9 MB/s  0:00:00
Downloading attrs-21.2.0-py2.py3-none-any.whl (53 kB)
Downloading jsonconversion-1.2.1-py3-none-any.whl (10 kB)
Downloading pyparsing-3.2.5-py3-none-any.whl (113 kB)
Downloading setuptools-78.1.1-py3-none-any.whl (1.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.3/1.3 MB 51.7 MB/s  0:00:00
Downloading numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.5/16.5 MB 211.3 MB/s  0:00:00
Installing collected packages: setuptools, pyparsing, numpy, attrs, jsonconversion, amazon.ion
Successfully installed amazon.ion-0.14.4 attrs-21.2.0 jsonconversion-1.2.1 numpy-2.2.6 pyparsing-3.2.5 setuptools-78.1.1
❯ pip show amazon.ion | grep Version
Version: 0.14.4
                            Version 2.0, January 2004
    Licensed under the Apache License, Version 2.0 (the "License");
❯ pip show amazon.ion | grep Version | head -1
Version: 0.14.4
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
